### PR TITLE
Initial modifications to q code

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,18 +341,18 @@ Gets options globally that affect LDAP operating procedures. Reference .ldap.get
 
 Syntax: `.ldap.getGlobalOption[option]`
 
-### .ldap.bind_s
+### .ldap.bind
 
 Synchronous bind operations are used to authenticate clients (and the users or applications behind them) to the directory server, to establish an authorization identity that will be used for subsequent operations processed on that connection, and to specify the LDAP protocol version that the client will use. See [here](https://ldap.com/the-ldap-bind-operation/) for reference documentation
 
-Syntax: `.ldap.bind_s[sess;dn;cred;mech]`
+Syntax: `.ldap.bind[sess;dn;cred;mech]`
 
 Where
 
 - sess is an int/long that represents the session previously created via .ldap.init
-- dn is a string/symbol. The DN of the user to authenticate. This should be empty for anonymous simple authentication, and is typically empty for SASL authentication because most SASL mechanisms identify the target account in the encoded credentials. It must be non-empty for non-anonymous simple authentication.
-- cred is a char/byte array or symbol. LDAP credentials (e.g. password). Pass empty string/symbol when no password required for connection.
-- mech is a string/symbol. Pass an empty string to use the default LDAP_SASL_SIMPLE mechanism. Query the attribute 'supportedSASLMechanisms' from the  server's rootDSE for the list of SASL mechanisms the server supports.
+- dn is a string/symbol. The DN of the user to authenticate. This should be an empty string/symbol or generic null for anonymous simple authentication, and is typically empty for SASL authentication because most SASL mechanisms identify the target account in the encoded credentials. It must be non-empty for non-anonymous simple authentication.
+- cred is a char/byte array or symbol. LDAP credentials (e.g. password). Pass empty string/symbol or generic null when no password required for connection.
+- mech is a string/symbol. Pass an empty string or generic null to use the default LDAP_SASL_SIMPLE mechanism. Query the attribute 'supportedSASLMechanisms' from the  server's rootDSE for the list of SASL mechanisms the server supports.
 
 Returns a dict consisting of 
 
@@ -367,7 +367,7 @@ Most of the security mechanisms are performed externally, in separate code relat
 
 For example,  DIGEST_MD5 is initially performed by calling bind with no credentials, mech set to "DIGEST-MD5" & capturing the returned credential values from the server. Using the returned credentials to MD5 encode the user details, a second bind call is then made with the MD5 encoded details as the 'cred' parameter. This requires an additional MD5 library that is outside the scope of this interface (Ref: [example code)](https://github.com/zheolong/melody-lib/blob/master/libldap5/sources/ldap/common/digest_md5.c). Other security mechanisms may operate in a similar manner (e.g. [GSSAPI](https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface) example [here](https://github.com/hajuuk/R7000/blob/master/ap/gpl/samba-3.0.13/source/libads/sasl.c), [CRAM-MD5](https://en.wikipedia.org/wiki/CRAM-MD5) available [here](https://github.com/illumos/illumos-gate/blob/master/usr/src/lib/libldap5/sources/ldap/common/cram_md5.c)).
 
-### .ldap.search_s
+### .ldap.search
 
 Synchronous search for partial or complete copies of entries based on a search criteria.
 
@@ -376,14 +376,14 @@ Syntax: .ldap.search_s[sess;baseDn;scope;filter;attrs;attrsOnly;timeLimit;sizeLi
 Where
 
 - sess is an int/long that represents the session previously created via .ldap.init
-- baseDn is a string/symbol. The base of the subtree to search from. An empty string/symbol can be used to search from the root (or when a DN is not known).
+- baseDn is a string/symbol. The base of the subtree to search from. An empty string/symbol or generic null can be used to search from the root (or when a DN is not known).
 - scope  is an int/long. Can be set to one of the following values:
   - 0 (LDAP_SCOPE_BASE) Only the entry specified will be considered in the search & no subordinates used
   - 1 (LDAP_SCOPE_ONELEVEL) Only search the immediate children of entry specified. Will not use the entry specified or further subordinates from the children.
   - 2 (LDAP_SCOPE_SUBTREE) To search the entry and all subordinates
   - 3 (LDAP_SCOPE_CHILDREN) To search all of the subordinates
 - filter is a string/symbol. The filter to be applied to the search ([reference](https://ldap.com/ldap-filters/))
-- attrs is a symbol list. The set of attributes to include in the result. If a specific set of attribute descriptions are listed, then only those attributes should be included in matching entries. The special value “*” indicates that all user attributes should be included in matching entries. The special value “+” indicates that all operational attributes should be included in matching entries. The special value “1.1” indicates that no attributes should be included in matching entries. Some servers may also support the ability to use the “@” symbol followed by an object class name (e.g., “@inetOrgPerson”) to request all attributes associated with that object class. If the set of attributes to request is empty, then the server should behave as if the value “*” was specified to request that all user attributes be included in entries that are returned.
+- attrs is a symbol list. The set of attributes to include in the result. If a specific set of attribute descriptions are listed, then only those attributes should be included in matching entries. The special value “*” indicates that all user attributes should be included in matching entries. The special value “+” indicates that all operational attributes should be included in matching entries. The special value “1.1” indicates that no attributes should be included in matching entries. Some servers may also support the ability to use the “@” symbol followed by an object class name (e.g., “@inetOrgPerson”) to request all attributes associated with that object class. If the set of attributes to request is an empty symbol/string or generic null, then the server should behave as if the value “*” was specified to request that all user attributes be included in entries that are returned.
 - attrsOnly is an int/long. Should be set to a non-zero value if only attribute descriptions are wanted. It should be set to zero (0) if both attributes descriptions and attribute values are wanted.
 - timeLimit is an int/long. Max number of microseconds to wait for a result. 0 represents no limit. Note that the server may impose its own limit.
 - sizeLimit is an int/long. Max number of entries to use in the result. 0 represents no limit. Note that the server may impose its own limit.
@@ -394,15 +394,15 @@ Returns a dict consisting of
 - Entries - table consisting of DNs and Attributes. Attribute forms a dictionary, were each attribute may contain one or more values.
 - Referrals - list of strings providing the referrals that can be searched to gain access to the required info (if server supports referrals)
 
-### .ldap.unbind_s
+### .ldap.unbind
 
 Synchronous unbind from the directory, terminate the current association, and free resources. Should be called even if a session did not bind (or failed to bind), but initialized its session.
 
-Syntax: `.ldap.unbind_s[sess]`
+Syntax: `.ldap.unbind[sess]`
 
 Where 
 
-- sess is an int/long that represents the session previously created via .ldap.init. The number should not longer be used unless .ldap.init and .ldap.bind_s has been used to create a new session.
+- sess is an int/long that represents the session previously created via .ldap.init. The number should no longer be used unless .ldap.init and .ldap.bind_s has been used to create a new session.
 
 ### .ldap.err2string
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,16 +24,16 @@ Kx docker image:
 `q root_dse.q`
 
 Local instance
-`q root_dse.q -host 0.0.0.0
+`q root_dse.q -host 0.0.0.0`
 
 ### search.q
 
 Created to show an example of an ldap search that works with the example LDAP server available from [https://github.com/rroemhild/docker-test-openldapi](https://github.com/rroemhild/docker-test-openldapi). Example searches provided in the script, such as searching for a users email. NOTE: this example server does not require a bind with user dn/password.
 
-Example
+*Example:*
 
 Kx docker image:
 `q search.q` 
 
 Local instance
-`q search.q -host 0.0.0.0
+`q search.q -host 0.0.0.0`

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,11 +20,9 @@ The connection details within the script may need altered to communicate with yo
 
 *Example:*
 
-Kx docker image:
-`q root_dse.q`
+Kx docker image: `q root_dse.q`
 
-Local instance
-`q root_dse.q -host 0.0.0.0`
+Local instance: `q root_dse.q -host 0.0.0.0`
 
 ### search.q
 
@@ -32,8 +30,6 @@ Created to show an example of an ldap search that works with the example LDAP se
 
 *Example:*
 
-Kx docker image:
-`q search.q` 
+Kx docker image: `q search.q` 
 
-Local instance
-`q search.q -host 0.0.0.0`
+Local instance: `q search.q -host 0.0.0.0`

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,9 +18,13 @@ Queries the servers rootDSE. Depending on the functionality your server supports
 
 The connection details within the script may need altered to communicate with your LDAP server.
 
-Example 
+*Example:*
 
+Kx docker image:
 `q root_dse.q`
+
+Local instance
+`q root_dse.q -host 0.0.0.0
 
 ### search.q
 
@@ -28,4 +32,8 @@ Created to show an example of an ldap search that works with the example LDAP se
 
 Example
 
-`q search.q`
+Kx docker image:
+`q search.q` 
+
+Local instance
+`q search.q -host 0.0.0.0

--- a/examples/root_dse.q
+++ b/examples/root_dse.q
@@ -1,26 +1,68 @@
 \l ldap.q
 \c 25 2000
 
+// Retrieve optional arguments for the example (default = example to be run from Kx docker image)
+dockerHost:enlist "host.docker.internal";
+cliOpts:.Q.def[``host!(`;dockerHost)].Q.opt .z.x
+if[dockerHost~cliOpts`host;
+  -1"Example is using 'host.docker.internal' to define host.\nIf not running in the Kx docker ",
+    "image set '-host x.x.x.x' on command line\n"
+  ]
+
 mainSession:1i
 timeout:3000000
 
 -1"### Creating global options";
-.ldap.setGlobalOption[`LDAP_OPT_X_TLS_REQUIRE_CERT;3]
-.ldap.setGlobalOption[`LDAP_OPT_PROTOCOL_VERSION;3]
-.ldap.setGlobalOption[`LDAP_OPT_NETWORK_TIMEOUT;timeout]
+TLSRequireCert :.ldap.setGlobalOption[`LDAP_OPT_X_TLS_REQUIRE_CERT;3]
+$[0i~TLSRequireCert;
+  [-1"'Request to globally set 'TLS_REQUIRE_CERT' option successfully processed'";];
+  [-2"'Request to globally set 'TLS_REQUIRE_CERT' option failed with return: '",
+     .ldap.err2string[TLSRequireCert],"'. Exiting.\n";
+   exit 1]
+  ]
 
--1"### Configuring LDAP server to use";
-.ldap.init[mainSession;enlist `$"ldap://host.docker.internal:389"]
+protocolVersion:.ldap.setGlobalOption[`LDAP_OPT_PROTOCOL_VERSION;3]
+$[0i~protocolVersion;
+  [-1"'Request to globally set 'LDAP_OPT_PROTOCOL_VERSION' option successfully processed'";];
+  [-2"'Request to globally set 'LDAP_OPT_PROTOCOL_VERSION' option failed with return: '",
+     .ldap.err2string[anonSearch`ReturnCode],"'. Exiting.\n";
+   exit 1]
+  ]
 
--1"### TLS Require Cert ";string .ldap.getOption[mainSession;`LDAP_OPT_X_TLS_REQUIRE_CERT]
--1"### Protocol version ";string .ldap.getOption[mainSession;`LDAP_OPT_PROTOCOL_VERSION]
--1"### Network timeout ";string .ldap.getOption[mainSession;`LDAP_OPT_NETWORK_TIMEOUT]
+networkTimeout :.ldap.setGlobalOption[`LDAP_OPT_NETWORK_TIMEOUT;timeout]
+$[0i~networkTimeout;
+  [-1"'Request to globally set 'LDAP_OPT_NETWORK_TIMEOUT' option successfully processed'";];
+  [-2"'Request to globally set 'LDAP_OPT_NETWORK_TIMEOUT' option failed with return: '",
+     .ldap.err2string[anonSearch`ReturnCode],"'. Exiting.\n";
+   exit 1]
+  ]
 
--1"### Connecting and searching for base attributes using anon bind";
-res:.ldap.search_s[mainSession;`$"";.ldap.LDAP_SCOPE_BASE;`$"(objectClass=*)";`$();0;0;0]
 
-if[0i<>res`ReturnCode;-2"### Request failed with : ",.ldap.err2string[res`ReturnCode];exit 1;]
+-1"\n\n### Configuring LDAP server to use";
+sessionInit:.ldap.init[mainSession;enlist `$"ldap://",cliOpts[`host;0],":389"]
+$[0i~sessionInit;
+  [-1"'Request to initialize a session successfully processed'";];
+  [-2"'Request to initialize a session failed with return: '",
+     .ldap.err2string[anonSearch`ReturnCode],"'. Exiting.\n";
+   exit 1]
+  ]
 
-show res
+
+-1"\n\n### Retrieve session options";
+-1"TLS Require Cert: ",string .ldap.getOption[mainSession;`LDAP_OPT_X_TLS_REQUIRE_CERT];
+-1"Protocol version: ",string .ldap.getOption[mainSession;`LDAP_OPT_PROTOCOL_VERSION];
+-1"Network timeout: ", string .ldap.getOption[mainSession;`LDAP_OPT_NETWORK_TIMEOUT];
+
+-1"\n\n### Connecting and searching for base attributes using anon bind";
+anonSearch:.ldap.search[mainSession;::;.ldap.LDAP_SCOPE_BASE;`$"(objectClass=*)";::;0;0;0]
+$[0i~anonSearch`ReturnCode;
+  [-1"'Request to run anonymous base attribute search successfully processed'";];
+  [-2"'Request to run anonymous base attribute search failed with return: '",
+     .ldap.err2string[anonSearch`ReturnCode],"'. Exiting.\n";
+   exit 1]
+  ]
+-1"\n### Complex subtree search results";
+show anonSearch
+-1"";
 
 exit 0

--- a/examples/search.q
+++ b/examples/search.q
@@ -1,31 +1,84 @@
 \l ldap.q
 \c 25 2000
 
+// Retrieve optional arguments for the example (default = example to be run from Kx docker image)
+dockerHost:enlist "host.docker.internal";
+cliOpts:.Q.def[``host!(`;dockerHost)].Q.opt .z.x
+if[dockerHost~cliOpts`host;
+  -1"Example is using 'host.docker.internal' to define host.\nIf not running in the Kx docker ",
+    "image set '-host x.x.x.x' on command line\n"
+  ]
+
 globalSession:1i
 
 -1"### Set LDAP server for session";
-.ldap.init[globalSession;enlist `$"ldap://host.docker.internal:389"]
+sessionInit:.ldap.init[globalSession;enlist `$"ldap://",cliOpts[`host;0],":389"]
+$[0i~sessionInit;
+  [-1"'Request to initialize a session successfully processed'";];
+  [-2"'Request to initialize a session failed with return: '",
+     .ldap.err2string[sessionInit],"'. Exiting.\n";
+   exit 1]
+  ]
 
--1"### Set session options";
-.ldap.setOption[globalSession;`LDAP_OPT_PROTOCOL_VERSION;3]
-.ldap.getOption[globalSession;`LDAP_OPT_API_INFO]
 
--1"### Bind to sessions server";
-.ldap.bind_s[globalSession;`$"";`$"";`$""]
+-1"\n\n### Update protocol version option and display update";
+protocolVersion:.ldap.setOption[globalSession;`LDAP_OPT_PROTOCOL_VERSION;3]
+$[0i~protocolVersion;
+  [-1"'Request to locally set 'LDAP_OPT_PROTOCOL_VERSION' option successfully processed'";];
+  [-2"'Request to locally set 'LDAP_OPT_PROTOCOL_VERSION' option failed with return: '",
+     .ldap.err2string[anonSearch`ReturnCode],"'. Exiting.\n";
+   exit 1]
+  ]
+show .ldap.getOption[globalSession;`LDAP_OPT_API_INFO]
 
--1"### Search at base level";
-res1:.ldap.search_s[globalSession;`$"";.ldap.LDAP_SCOPE_BASE;`$"(objectClass=*)";`$();0;0;0]
-if[0i<>res1`ReturnCode;-2"### Request failed with : ",.ldap.err2string[res1`ReturnCode];exit 1;]
--1"### Search results";
-show res1
 
--1"### Search from ou=people,dc=planetexpress,dc=com and subtree below for Amy, get givenName and email";
-res2:.ldap.search_s[globalSession;`$"ou=people,dc=planetexpress,dc=com";.ldap.LDAP_SCOPE_SUBTREE;"(cn=Amy Wong)";(`$"mail";`$"givenName");0;0;0]
-if[0i<>res2`ReturnCode;-2"### Request failed with : ",.ldap.err2string[res2`ReturnCode];exit 1;]
--1"### Search results";
-show res2
+-1"\n\n### Bind to sessions server";
+bindSession:.ldap.bind[globalSession;::;::;::]
+$[0i~bindSession`ReturnCode;
+  [-1"'Request to bind to sessions server successfully processed'";];
+  [-2"Request to bind to server failed with return: '",
+   .ldap.err2string[bindSession`ReturnCode],"'. Exiting.\n";
+   exit 1]
+  ]
 
--1"### UnBind from session";
-.ldap.unbind_s[globalSession]
+
+-1"\n\n### Search at base level";
+baseSearch:.ldap.search[globalSession;::;.ldap.LDAP_SCOPE_BASE;`$"(objectClass=*)";::;0;0;0]
+$[0i~ baseSearch`ReturnCode;
+  [-1"'Request to search at base level successfully processed'";];
+  [-2"Request to search at base level failed with return: '",
+   .ldap.err2string[baseSearch`ReturnCode],"'. Exiting.\n";
+   exit 1]
+  ]
+-1"\n### Base search results";
+show baseSearch
+
+
+-1"\n\n### Search from ou=people,dc=planetexpress,dc=com and subtree below for Amy. ",
+  "Retrieve givenName and email";
+// paramter definitions
+treeBase:`$"ou=people,dc=planetexpress,dc=com"
+scope   :.ldap.LDAP_SCOPE_SUBTREE
+filter  :"(cn=Amy Wong)"
+attrs   :`mail`givenName
+complexSearch:.ldap.search[globalSession;treeBase;scope;filter;attrs;0;0;0]
+$[0i~complexSearch`ReturnCode;
+  [-1"'Request to apply complex subtree search successfully processed'";];
+  [-2"Request to complete complex subtree search failed with return: '",
+     .ldap.err2string[complexSearch`ReturnCode],"'. Exiting.\n";
+   exit 1]
+  ]
+-1"\n### Complex subtree search results";
+show complexSearch
+
+
+-1"\n\n### UnBind from session";
+unBindSession:.ldap.unbind[globalSession]
+$[0i~unBindSession;
+  [-1"'Request to unbind from the session successfully processed'.\n";];
+  [-1"Request to unbind from session failed with return: '",
+     unBindSession,"'. Exiting.\n";
+   exit 1]
+  ]
 
 exit 0

--- a/q/ldap.q
+++ b/q/ldap.q
@@ -12,14 +12,13 @@ unbind_s:`kdbldap 2:(`kdbldap_unbind_s;1)
 err2string:`kdbldap 2:(`kdbldap_err2string;1)
 
 bind:{[sess;baseDN;cred;mech]
-  {if[x~(::);x set `}each `baseDN`cred`mech;
-  bind_s[sess;dn;cred;mech]
+  if[baseDN~(::);baseDN:`];if[cred~(::);cred:`];if[mech~(::);mech:`];
+  bind_s[sess;baseDN;cred;mech]
   }
 
-search:{[sess;baseDN;scope;filter;attr;attrsOnly;timeLimit;sizeLimit]
-  if[baseDN~(::);baseDN:`];
-  if[filter~(::);filter:`$()];
-  search_s[sess;baseDN;scope;filter;attr;attrsOnly;timeLimit;sizeLimit]
+search:{[sess;baseDN;scope;filter;attrib;attrsOnly;timeLimit;sizeLimit]
+  if[baseDN~(::);baseDN:`];if[filter~(::);filter:`$()];if[attrib~(::);attrib:`$()];
+  search_s[sess;baseDN;scope;filter;attrib;attrsOnly;timeLimit;sizeLimit]
   }
 
 unbind:unbind_s

--- a/q/ldap.q
+++ b/q/ldap.q
@@ -11,6 +11,20 @@ search_s:`kdbldap 2:(`kdbldap_search_s;8)
 unbind_s:`kdbldap 2:(`kdbldap_unbind_s;1)
 err2string:`kdbldap 2:(`kdbldap_err2string;1)
 
+bind:{[sess;baseDN;cred;mech]
+  {if[x~(::);x set `}each `baseDN`cred`mech;
+  bind_s[sess;dn;cred;mech]
+  }
+
+search:{[sess;baseDN;scope;filter;attr;attrsOnly;timeLimit;sizeLimit]
+  if[baseDN~(::);baseDN:`];
+  if[filter~(::);filter:`$()];
+  search_s[sess;baseDN;scope;filter;attr;attrsOnly;timeLimit;sizeLimit]
+  }
+
+unbind:unbind_s
+
+
 LDAP_SCOPE_BASE:0
 LDAP_SCOPE_ONELEVEL:1
 LDAP_SCOPE_SUBTREE:2


### PR DESCRIPTION
* Functions which have accepted default behaviour ```(`/"")``` can now also take a generic null `(::)` in line with recent ML releases
* Functions for binding, unbinding and search no longer contain underscore syntax to indicate synchronous. Instead just `bind`/`unbind`/`search` until async added
* README.md files updated in line with the above
* Examples updated
  * Addition of command line option `-host` being added allows the example to be used locally not just in the docker image (default is the docker image still but will highlight to the user that this assumption was made)
  * Descriptions of outputs changed broadly with any functions that could fail now indicating either success or failure messages
