### PR TITLE
copy/paste artefacts were present in error handling of examples

### DIFF
--- a/examples/root_dse.q
+++ b/examples/root_dse.q
@@ -25,7 +25,7 @@ protocolVersion:.ldap.setGlobalOption[`LDAP_OPT_PROTOCOL_VERSION;3]
 $[0i~protocolVersion;
   [-1"'Request to globally set 'LDAP_OPT_PROTOCOL_VERSION' option successfully processed'";];
   [-2"'Request to globally set 'LDAP_OPT_PROTOCOL_VERSION' option failed with return: '",
-     .ldap.err2string[anonSearch`ReturnCode],"'. Exiting.\n";
+     .ldap.err2string[protocolVersion],"'. Exiting.\n";
    exit 1]
   ]
 
@@ -33,7 +33,7 @@ networkTimeout :.ldap.setGlobalOption[`LDAP_OPT_NETWORK_TIMEOUT;timeout]
 $[0i~networkTimeout;
   [-1"'Request to globally set 'LDAP_OPT_NETWORK_TIMEOUT' option successfully processed'";];
   [-2"'Request to globally set 'LDAP_OPT_NETWORK_TIMEOUT' option failed with return: '",
-     .ldap.err2string[anonSearch`ReturnCode],"'. Exiting.\n";
+     .ldap.err2string[networkTimeout],"'. Exiting.\n";
    exit 1]
   ]
 
@@ -43,7 +43,7 @@ sessionInit:.ldap.init[mainSession;enlist `$"ldap://",cliOpts[`host;0],":389"]
 $[0i~sessionInit;
   [-1"'Request to initialize a session successfully processed'";];
   [-2"'Request to initialize a session failed with return: '",
-     .ldap.err2string[anonSearch`ReturnCode],"'. Exiting.\n";
+     .ldap.err2string[sessionInit],"'. Exiting.\n";
    exit 1]
   ]
 

--- a/examples/search.q
+++ b/examples/search.q
@@ -26,7 +26,7 @@ protocolVersion:.ldap.setOption[globalSession;`LDAP_OPT_PROTOCOL_VERSION;3]
 $[0i~protocolVersion;
   [-1"'Request to locally set 'LDAP_OPT_PROTOCOL_VERSION' option successfully processed'";];
   [-2"'Request to locally set 'LDAP_OPT_PROTOCOL_VERSION' option failed with return: '",
-     .ldap.err2string[anonSearch`ReturnCode],"'. Exiting.\n";
+     .ldap.err2string[protocolVersion],"'. Exiting.\n";
    exit 1]
   ]
 show .ldap.getOption[globalSession;`LDAP_OPT_API_INFO]
@@ -77,7 +77,7 @@ unBindSession:.ldap.unbind[globalSession]
 $[0i~unBindSession;
   [-1"'Request to unbind from the session successfully processed'.\n";];
   [-1"Request to unbind from session failed with return: '",
-     unBindSession,"'. Exiting.\n";
+     .ldap.err2string[unBindSession],"'. Exiting.\n";
    exit 1]
   ]
 


### PR DESCRIPTION
A number of copy/paste artefacts present in error handling of examples. Updates to correctly catch these