### PR TITLE
Search/bind default dictionary functionality. Closes #119

### DIFF
--- a/examples/root_dse.q
+++ b/examples/root_dse.q
@@ -51,10 +51,10 @@ $[0i~sessionInit;
 -1"\n\n### Retrieve session options";
 -1"TLS Require Cert: ",string .ldap.getOption[mainSession;`LDAP_OPT_X_TLS_REQUIRE_CERT];
 -1"Protocol version: ",string .ldap.getOption[mainSession;`LDAP_OPT_PROTOCOL_VERSION];
--1"Network timeout: ", string .ldap.getOption[mainSession;`LDAP_OPT_NETWORK_TIMEOUT];
+-1"Network timeout : ", string .ldap.getOption[mainSession;`LDAP_OPT_NETWORK_TIMEOUT];
 
 -1"\n\n### Connecting and searching for base attributes using anon bind";
-anonSearch:.ldap.search[mainSession;::;.ldap.LDAP_SCOPE_BASE;`$"(objectClass=*)";::;0;0;0]
+anonSearch:.ldap.search[mainSession;.ldap.LDAP_SCOPE_BASE;`$"(objectClass=*)";::]
 $[0i~anonSearch`ReturnCode;
   [-1"'Request to run anonymous base attribute search successfully processed'";];
   [-2"'Request to run anonymous base attribute search failed with return: '",

--- a/examples/search.q
+++ b/examples/search.q
@@ -33,7 +33,7 @@ show .ldap.getOption[globalSession;`LDAP_OPT_API_INFO]
 
 
 -1"\n\n### Bind to sessions server";
-bindSession:.ldap.bind[globalSession;::;::;::]
+bindSession:.ldap.bind[globalSession;::]
 $[0i~bindSession`ReturnCode;
   [-1"'Request to bind to sessions server successfully processed'";];
   [-2"Request to bind to server failed with return: '",
@@ -41,9 +41,14 @@ $[0i~bindSession`ReturnCode;
    exit 1]
   ]
 
+-1"\n### Bind to session results";
+show bindSession
+
 
 -1"\n\n### Search at base level";
-baseSearch:.ldap.search[globalSession;::;.ldap.LDAP_SCOPE_BASE;`$"(objectClass=*)";::;0;0;0]
+baseScope :.ldap.LDAP_SCOPE_BASE
+baseFilter:"(objectClass=*)"
+baseSearch:.ldap.search[globalSession;baseScope;baseFilter;::]
 $[0i~ baseSearch`ReturnCode;
   [-1"'Request to search at base level successfully processed'";];
   [-2"Request to search at base level failed with return: '",
@@ -57,11 +62,10 @@ show baseSearch
 -1"\n\n### Search from ou=people,dc=planetexpress,dc=com and subtree below for Amy. ",
   "Retrieve givenName and email";
 // paramter definitions
-treeBase:`$"ou=people,dc=planetexpress,dc=com"
-scope   :.ldap.LDAP_SCOPE_SUBTREE
-filter  :"(cn=Amy Wong)"
-attrs   :`mail`givenName
-complexSearch:.ldap.search[globalSession;treeBase;scope;filter;attrs;0;0;0]
+customScope :.ldap.LDAP_SCOPE_SUBTREE
+customFilter:"(cn=Amy Wong)"
+customDict  :`baseDN`attr!(`$"ou=people,dc=planetexpress,dc=com";`mail`givenName)
+complexSearch:.ldap.search[globalSession;customScope;customFilter;customDict]
 $[0i~complexSearch`ReturnCode;
   [-1"'Request to apply complex subtree search successfully processed'";];
   [-2"Request to complete complex subtree search failed with return: '",
@@ -76,8 +80,8 @@ show complexSearch
 unBindSession:.ldap.unbind[globalSession]
 $[0i~unBindSession;
   [-1"'Request to unbind from the session successfully processed'.\n";];
-  [-1"Request to unbind from session failed with return: '",
-     .ldap.err2string[unBindSession],"'. Exiting.\n";
+  [-2"Request to unbind from session failed with return: '",
+     unBindSession,"'. Exiting.\n";
    exit 1]
   ]
 

--- a/q/ldap.q
+++ b/q/ldap.q
@@ -11,14 +11,27 @@ search_s:`kdbldap 2:(`kdbldap_search_s;8)
 unbind_s:`kdbldap 2:(`kdbldap_unbind_s;1)
 err2string:`kdbldap 2:(`kdbldap_err2string;1)
 
-bind:{[sess;baseDN;cred;mech]
-  if[baseDN~(::);baseDN:`];if[cred~(::);cred:`];if[mech~(::);mech:`];
-  bind_s[sess;baseDN;cred;mech]
+
+bind:{[sess;customDict]
+  defaultKeys:`dn`cred`mech;
+  defaultVals:```;
+  defaultDict:defaultKeys!defaultVals;
+  if[customDict~(::);customDict:()!()];
+  if[99h<>type customDict;'"customDict must be (::) or a dictionary"];
+  updDict:defaultDict,customDict;
+  bindSession:bind_s[sess;;;]. updDict defaultKeys;
+  bindSession
   }
 
-search:{[sess;baseDN;scope;filter;attrib;attrsOnly;timeLimit;sizeLimit]
-  if[baseDN~(::);baseDN:`];if[filter~(::);filter:`$()];if[attrib~(::);attrib:`$()];
-  search_s[sess;baseDN;scope;filter;attrib;attrsOnly;timeLimit;sizeLimit]
+search:{[sess;scope;filter;customDict]
+  defaultKeys:`baseDN`attr`attrsOnly`timeLimit`sizeLimit;
+  defaultVals:(`$"";`$();0;0;0);
+  defaultDict:defaultKeys!defaultVals;
+  if[customDict~(::);customDict:()!()];
+  if[99h<>type customDict;'"customDict must be (::) or a dictionary"];
+  updDict:defaultDict,customDict;
+  searchRes:search_s[sess;;scope;filter;;;;]. updDict defaultKeys;
+  searchRes
   }
 
 unbind:unbind_s


### PR DESCRIPTION
Local repo update required to allow merge rebase functionality 

Both the functions `.ldap.search` and `.ldap.bind` have been modified to take a dictionary as input in place of parameters which have 'natural' defaults

`.ldap.search` now takes 4 parameters
1. `sess` the integer representing a session created with `.ldap.init`
2. `scope` the integer representing the scope of how a search should take place
3.  `filter` the string representing how to filter the search process
4.  `customDict` a dictionary where a user can overwrite the default operation of the 'old' parameters ``` `baseDn`attr`attrsOnly`timeLimit`sizeLimit ```

`.ldap.search` now takes 2 parameters
1. `sess` the integer representing a session created with `.ldap.init`
2.  `customDict` a dictionary where a user can overwrite the default operation of the 'old' parameters ``` `dn`cred`mech ```

This addition closes #119