### PR TITLE
Enable start tls

### DIFF
--- a/q/ldap.q
+++ b/q/ldap.q
@@ -2,6 +2,7 @@
 
 /  intialise ldap functions
 init:`kdbldap 2:(`kdbldap_init;2)
+startTLS:`kdbldap 2:(`kdbldap_start_tls;1)
 setOption:`kdbldap 2:(`kdbldap_set_option;3)
 setGlobalOption:`kdbldap 2:(`kdbldap_set_global_option;2)
 getOption:`kdbldap 2:(`kdbldap_get_option;2)

--- a/src/kdbldap.c
+++ b/src/kdbldap.c
@@ -78,6 +78,16 @@ K kdbldap_init(K sess, K uris)
     return ki(res);
 }
 
+K kdbldap_start_tls(K sess)
+{
+    CHECK_PARAM_INT_TYPE(sess,"start_tls");
+    int idx = getInt(sess);
+    void* session = getSession(idx);
+    CHECK_SESSION(session);
+    int res= ldap_start_tls_s(session,NULL,NULL);
+    return ki(res);
+}
+
 static K setStringOption(LDAP* ld, int option, K value)
 {
     CHECK_PARAM_STRING_TYPE(value,"set_option");

--- a/src/kdbldap.h
+++ b/src/kdbldap.h
@@ -24,6 +24,17 @@ extern "C" {
 EXP K kdbldap_init(K sess,K uris);
 
 /**
+ * Sends a StartTLS request to a server, waits for the reply, and 
+ * then installs TLS handlers on the session if the request succeeded. 
+ * The routine returns LDAP_SUCCESS if everything succeeded, otherwise 
+ * it returns an LDAP error code
+ *
+ * @param sess int/long that represents the session previously 
+ * created via .ldap.init
+ */
+EXP K kdbldap_start_tls(K sess);
+
+/**
  * Sets options globally that affect LDAP operating procedures
  * 
  * @param option a symbol for the option you wish to set globally


### PR DESCRIPTION
In this commit I am adding a function, **.ldap.startTLS**, which enables a startTLS connection with the server.
startTLS works with the normal LDAP port ldap://<hostname>:389  (not ldaps://)

This function is a wrapper around **ldap_start_tls_s** (See [reference](https://www.openldap.org/software//man.cgi?query=ldap_start_tls&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release)).

**ldap_start_tls_s** sends a StartTLS request to a server, waits for the reply, and then installs TLS handlers on the session if the request succeeded. The routine returns LDAP_SUCCESS if everything succeeded, otherwise it returns an LDAP error code.

The **ldap_start_tls_s** function takes 3 arguments, the session ID, ServerCtrls and ClientCtrls.
Both ServerCtrls and ClientCtrls are being set to NULL to be consistent with what is done for ldap_sasl_bind_s.
Hence, **.ldap.startTLS** only requires a single argument, the session ID.

To enable an LDAP node to accept only startTLS connections the olcSecurity setting should be set to tls=1 or higher


Example Usage:

    q).ldap.init[1i;enlist `$"ldap://localhost:389"]  
    q).ldap.setOption[1i;`LDAP_OPT_PROTOCOL_VERSION;3] 
    q).ldap.startTLS[1i]  
    0i  
    q).ldap.bind[1i;`dn`cred!(dn;"password1")] 







