### PR TITLE
Update openldap lib for linux. Closes #128

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 jobs:
   include:
-  - dist: xenial
-    os: linux
-  - dist: trusty 
+  - dist: focal
     os: linux
   - dist: bionic
     os: linux
@@ -97,5 +95,5 @@ deploy:
   file: "$FILE_NAME"
   on:
     tags: true
-    condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = trusty && $TRAVIS_OS_NAME = linux) 
+    condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = bionic && $TRAVIS_OS_NAME = linux) 
   skip_cleanup: 'true' #  prevent Travis CI from resetting your working directory and deleting all changes made during the build 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -4,12 +4,13 @@ RUN yum -y install gcc && \
     yum -y install cmake && \
     yum -y install make && \
     yum -y install vim && \
-    yum -y install openssl-devel.x86_64 && \
     yum -y install wget
 
 RUN yum clean all
 
-RUN mkdir -p /source/api/ /source/code/ && cd /source/api && wget https://www.openldap.org/software//download/OpenLDAP/openldap-release/openldap-2.4.50.tgz && tar xvf openldap-2.4.50.tgz --strip-components=1
+RUN cd /tmp && wget --no-check-certificate https://ftp.openssl.org/source/old/1.1.1/openssl-1.1.1.tar.gz && tar xvf openssl-1.1.1.tar.gz && cd openssl-1.1.1/ && ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib && make && make install
+
+RUN mkdir -p /source/api/ /source/code/ && cd /source/api && wget --no-check-certificate https://www.openldap.org/software//download/OpenLDAP/openldap-release/openldap-2.6.3.tgz && tar xvf openldap-2.6.3.tgz --strip-components=1
 RUN cd /source/api/ && ./configure --disable-slapd --with-tls=openssl && make && make install
 WORKDIR /source/code/
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ or
 
 The latest release of OpenLdap is referenced [here](https://www.openldap.org/software/release/)
 
-For example, the 2.4.50 release is available in source form from [here](https://www.openldap.org/software//download/OpenLDAP/openldap-release/openldap-2.6.3.tgz )
+For example, the 2.6.3 release is available in source form from [here](https://www.openldap.org/software//download/OpenLDAP/openldap-release/openldap-2.6.3.tgz )
 
 To build/install, unzip the downloaded source and run
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ or
 
 The latest release of OpenLdap is referenced [here](https://www.openldap.org/software/release/)
 
-For example, the 2.4.50 release is available in source form from [here](https://www.openldap.org/software//download/OpenLDAP/openldap-release/openldap-2.4.50.tgz )
+For example, the 2.4.50 release is available in source form from [here](https://www.openldap.org/software//download/OpenLDAP/openldap-release/openldap-2.6.3.tgz )
 
 To build/install, unzip the downloaded source and run
 

--- a/travis_setup.sh
+++ b/travis_setup.sh
@@ -8,8 +8,8 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   cp -r /usr/local/opt/openldap/lib ./cbuild/
   cp -r /usr/local/opt/openldap/include ./cbuild/
 elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
-  wget -q https://www.openldap.org/software//download/OpenLDAP/openldap-release/openldap-2.4.50.tgz 
-  tar xvf openldap-2.4.50.tgz -C ./cbuild --strip-components=1
+  wget -q https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.3.tgz
+  tar xvf openldap-2.6.3.tgz -C ./cbuild --strip-components=1
   cd cbuild
   ./configure --disable-slapd --with-tls=openssl
   make


### PR DESCRIPTION
trusty on travis now depreciated
prev used OpenLDAP lib wasnt supported anymore
newer openldap needs newer ssl libs
