### PR TITLE
:warning: imported docs prior to removal from code.kx.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
-# LDAP interface for KDB+
+# LDAP interface for kdb+
+
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/kxsystems/ldap?include_prereleases)](https://github.com/kxsystems/ldap/releases) [![Travis (.org) branch](https://img.shields.io/travis/kxsystems/ldap/master?label=travis%20build)](https://travis-ci.org/kxsystems/ldap/branches)
 
-## Introduction
 
-This interface allows KDB+ to interact with the Lightweight Directory Access Protocol (LDAP). This API permits a client to authenticate & search against an LDAP server. The interface is a thin wrapper against the open source OpenLDAP library. General info on this API is available [here](https://www.openldap.org/software/man.cgi?query=ldap&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release).
 
-In addition to authentication/authorization uses, depending on the data stored on your LDAP server, it could be used to access data for analytics e.g.
+This interface allows kdb+ to interact with the Lightweight Directory Access Protocol (LDAP). This API permits a client to authenticate and search against an LDAP server. The interface is a thin wrapper around the open-source OpenLdap library. General info on this API is available [here](https://www.openldap.org/software/man.cgi?query=ldap&sektion=3&apropos=0&manpath=OpenLdap+2.4-Release).
+
+In addition to authentication and authorization uses, depending on the data stored on your LDAP server, it could be used to access data for analytics e.g.
 
 - company staff turnover (if user creation date/leave dates/etc recorded)
 - IT equipment approaching end of life (if hardware details recorded)
 - staff departmental memberships
 
-## New to KDB+ ?
+## New to kdb+ ?
 
-Kdb+ is the world's fastest time-series database, optimized for ingesting, analyzing and storing massive amounts of structured data. To get started with kdb+, please visit https://code.kx.com/q/learn/ for downloads and developer information. For general information, visit https://kx.com/
+Kdb+ is the world's fastest time-series database, optimized for ingesting, analyzing and storing massive amounts of structured data. To get started with kdb+, please visit https://code.kx.com/q/ for downloads and developer information. For general information, visit https://kx.com/
 
 ## New to LDAP?
 
@@ -29,138 +30,144 @@ Download the latest release from our [releases page](https://github.com/KxSystem
 
 #### Linux
 
-Prior to using this interface, the openldap library package should be installed (e.g. redhat releases may include openldap package by default), which includes libldap.so. The latest openldap can also be build & installed from source, by obtaining the latest release from [here](https://openldap.org/).
+Prior to using this interface, the OpenLdap library package should be installed (e.g. RedHat releases may include OpenLdap package by default), which includes `libldap.so`. The latest OpenLdap can also be built and installed from source, by obtaining the latest release from [here](https://openldap.org/).
 
-To install this kdb ldap library and scripts, either
+To install this kdb+ LDAP library and scripts, either
 
-- run the provided install.sh
+- run the provided `install.sh`
 
 or
 
-- copy `kdbldap.so` which was built or downloaded earlier to your kdb+ folder. If on a Linux 64bit machine with kdb+ installed in `/usr/local/q`, place the shared library into `/usr/local/q/l64/`.
+- copy `kdbldap.so` which was built or downloaded earlier to your kdb+ folder. If on a Linux 64-bit machine with kdb+ installed in `/usr/local/q`, place the shared library into `/usr/local/q/l64/`.
 - the q script to load the ldap API (`ldap.q`) can be placed in the current working directory or within the kdb+ install directory.
 
 #### Windows
 
-You can build OpenLdap from [source](https://openldap.org/software/download/), or use a package manager such as pacman thats provided with [msys64](https://www.msys2.org/). The OpenLdap libs be moved from your install  (e.g. if using mssys and pacman, these libs may be found in the mingw64\bin directory) to the KDB+ w64 directory. The OpenLdap libs required are:
+You can build OpenLdap from [source](https://openldap.org/software/download/), or use a package manager, such as pacman, provided with [msys64](https://www.msys2.org/). Move the OpenLdap libs from your install  (e.g. if using mssys and pacman, these libs may be found in the `mingw64\bin` directory) to the kdb+ `w64` directory. The OpenLdap libs required are:
 
-- libcrypto-1_1-x64.dll
-- liblber.dll
-- libldap.dll
-- libsasl2-3.dll
-- libssl-1_1-x64.dll
+- `libcrypto-1_1-x64.dll`
+- `liblber.dll`
+- `libldap.dll`
+- `libsasl2-3.dll`
+- `libssl-1_1-x64.dll`
 
 To install the library and scripts interface that this repo provides, either
 
-- run the provided install.bat
+- run the provided `install.bat`
 
 or
 
-- copy `kdbldap.dll` which was built or downloaded earlier, to your kdb+ install binary dir e.g. if KDB+ installed at `C:\q`, place the shared library into `C:\q\w64\`.
-- copy the q script to load the ldap API (`ldap.q`) can be placed in the current working directory or within the kdb+ install directory.
+- copy `kdbldap.dll` which was built or downloaded earlier, to your kdb+ install binary dir e.g. if kdb+ installed at `C:\q`, place the shared library into `C:\q\w64\`.
+- copy the q script to load the LDAP API (`ldap.q`) in the current working directory or within the kdb+ install directory.
 
-#### Mac (Intel)
+#### macOS (Intel)
 
-You can build OpenLdap from [source](https://openldap.org/software/download/), or use a package manager such as homebrew. The [HomeBrew](https://brew.sh/) package manager provides a installation of OpenLdap. Once HomeBrew is available on your mac, run the following to install OpenLdap
+You can build OpenLdap from [source](https://openldap.org/software/download/), or use a package manager such as HomeBrew. The [HomeBrew](https://brew.sh/) package manager provides a installation of OpenLdap. Once HomeBrew is available on your Mac, run the following to install OpenLdap
 
-`brew install openldap`
+```bash
+brew install OpenLdap
+```
 
 To install the library and scripts, either
 
-- run the provided install.sh
+- run the provided `install.sh`
 
 or
 
 - Copy `kdbldap.so` which was built or downloaded earlier, to your kdb+ install binary dir e.g. if kdb+ installed at `/usr/local/q`, place the shared library into `/usr/local/q/m64/`..
 - The q script to load the ldap API (`ldap.q`) can be placed in the current working directory or within the kdb+ install directory.
 
-## Building Interface From Source
+## Building the interface from source
 
 ### Linux
 
-#### Linux OpenLdap Builds
+#### Linux OpenLdap builds
 
-The latest release of OpenLdap is referenced [here](https://www.openldap.org/software/release/)
+The latest release of OpenLdap is at https://www.openldap.org/software/release.
 
-For example, the 2.6.3 release is available in source form from [here](https://www.openldap.org/software//download/OpenLDAP/openldap-release/openldap-2.6.3.tgz )
+For example, the 2.6.3 release is available in source form from 
+
+https://www.openldap.org/software/download/openldap/openldap-release/openldap-2.6.3.tgz 
 
 To build/install, unzip the downloaded source and run
 
-```
+```bash
 ./configure --disable-slapd --with-tls=openssl
- make
- make install
+make
+make install
 ```
 
-#### Building Linux Interface
+#### Building the Linux interface
 
-After unstalling OpenLdap, to create a build within the build directory run the following:
+After installing OpenLdap, to create a build within the `build` directory run the following:
 
-```
+```bash
 cd build
 cmake ../
 make install
 ```
 
-You should then find the resulting files in a newly created api dir, which should reside within the build directory.
+You should then find the resulting files in a newly created `api` dir within the `build` directory.
 
 ### Windows
 
-#### Windows OpenLdap Builds
+#### Windows OpenLdap builds
 
-Pre-built OpenLdap Windows libraries can be retrieved using pacman package manager (supplied with msys2). The package is [mingw-w64-x86_64-openldap](https://packages.msys2.org/package/mingw-w64-x86_64-openldap). Example instruction for install
+Pre-built OpenLdap Windows libraries can be retrieved using pacman package manager (supplied with MSYS2). The package is [`mingw-w64-x86_64-openldap`](https://packages.msys2.org/package/mingw-w64-x86_64-openldap). Example instruction for install
 
-```
+```shell
 # update database of packages
 pacman -Fy
-# search for openldap package name
-pacman -Ss openldap
+# search for OpenLdap package name
+pacman -Ss OpenLdap
 # list contents of package prior to install
 pacman -Fl <x64 package name found in prev search>
 # install package
 pacman -S <x64 package name found in prev search>
 ```
 
-##### Converting msys2 provided libldap.dll to libldap.lib for use with Visual Studio
+##### Converting MSYS2-provided `libldap.dll` to `libldap.lib` for use with Visual Studio
 
-Use the provided dll2lib.bat to convert liblber.dll and libldap.dll (found in the mingw64/bin dir of your msys2 install).
+Use the provided `dll2lib.bat` to convert `liblber.dll` and `libldap.dll` (found in the `mingw64/bin` dir of your MSYS2 install).
 
-The batch file dll2lib.bat should be run from a VS command prompt in order to use tools from Visual Studio.
+The batch file `dll2lib.bat` should be run from a VS command prompt in order to use tools from Visual Studio.
 
-```
+```shell
 dll2lib.bat liblber.dll
 dll2lib.bat libldap.dll
 ```
 
-Move the resulting liblber.lib and libldap.lib to the mingw64/lib dir of your msys2 install.
+Move the resulting `liblber.lib` and `libldap.lib` to the `mingw64/lib` dir of your MSYS2 install.
 
-### Building Windows Interface
+### Building Windows interface
 
 ##### Example build command using Visual Studio 2019
 
-Open 'x64 Native Tools Command Prompt for VS 2019' as supplied with Visual Studio.
+Open _x64 Native Tools Command Prompt for VS 2019_ as supplied with Visual Studio.
 
-Go to the downloaded source & enter the build directory. Run the following builds commands
+Go to the downloaded source and enter the `build` directory. Run the following builds commands
 
-```
-set BUILD_HOME=<dir containing lib and include directory of the openldap library>
+```shell
+set BUILD_HOME=<dir containing lib and include directory of the OpenLdap library>
 cmake -G "Visual Studio 16 2019" -A x64 ..
 MSBuild.exe INSTALL.vcxproj /m /nologo /verbosity:normal /p:Configuration=Release /p:Platform=x64
 ```
 
-Created libs/etc can then be found in the newly created kdbldap dir
+Created libs/etc can then be found in the newly created `kdbldap` dir
 
-### Mac
+### macOS
 
-#### Mac OpenLdap Builds
+#### macOS OpenLdap builds
 
-The [HomeBrew](https://brew.sh/) install manager provides a installation of OpenLdap. Once HomeBrew is available on your mac, run the following to install OpenLdap
+The [HomeBrew](https://brew.sh/) install manager installs OpenLdap. Once HomeBrew is available on your machine, run the following to install OpenLdap
 
-`brew install openldap`
+```bash
+brew install openldap
+```
 
-#### Building Mac Interface
+#### Building the macOS interface
 
-Building the interface from source requires `gcc`, `gcc c++`, `make` and `cmake` packages installed on your development machine (e.g. xcode for Mac).
+Building the interface from source requires `gcc`, `gcc c++`, `make` and `cmake` packages installed on your development machine (e.g. Xcode for Mac).
 
 Follow these steps
 
@@ -169,294 +176,32 @@ Follow these steps
 3. Run `cmake`
 4. Run `make install`
 
-For example, on Linux/Mac, to create a build within the build directory
+For example, on Linux/macOS, to create a build within the `build` directory
 
-```
-export BUILD_HOME=/usr/local/opt/openldap/
+```bash
+export BUILD_HOME=/usr/local/opt/OpenLdap/
 cd build
 cmake ../
 make install
 ```
 
-You should then find the resulting files in a newly created api dir, which should reside within the build directory.
+You should then find the resulting files in a newly created `api` dir within the `build` directory.
 
-## OpenLdap License
+## OpenLdap license
 
-Thirdparty OpenLdap license
+> Third-party OpenLdap license
+> 
+> The OpenLdap Public License  Version 2.8, 17 August 2003 Redistribution and use of this software and associated documentation ("Software"), with or without modification, are permitted provided that the following conditions are met: 1. Redistributions in source form must retain copyright statements   and notices, 2. Redistributions in binary form must reproduce applicable copyright   statements and notices, this list of conditions, and the following   disclaimer in the documentation and/or other materials provided   with the distribution, and 3. Redistributions must contain a verbatim copy of this document. The OpenLdap Foundation may revise this license from time to time. Each revision is distinguished by a version number.  You may use this Software under terms of this license revision or under the terms of any subsequent revision of the license. THIS SOFTWARE IS PROVIDED BY THE OpenLdap FOUNDATION AND ITS CONTRIBUTORS “AS IS” AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenLdap FOUNDATION, ITS CONTRIBUTORS, OR THE AUTHOR(S) OR OWNER(S) OF THE SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. The names of the authors and copyright holders must not be used in advertising or otherwise to promote the sale, use or other dealing in this Software without specific, written prior permission.  Title to copyright in this Software shall at all times remain with copyright holders. OpenLdap is a registered trademark of the OpenLdap Foundation. Copyright 1999-2003 The OpenLdap Foundation, Redwood City, California, USA.  All Rights Reserved.  Permission to copy and distribute verbatim copies of this document is granted.
 
-The OpenLDAP Public License  Version 2.8, 17 August 2003 Redistribution and use of this software and associated documentation ("Software"), with or without modification, are permitted provided that the following conditions are met: 1. Redistributions in source form must retain copyright statements   and notices, 2. Redistributions in binary form must reproduce applicable copyright   statements and notices, this list of conditions, and the following   disclaimer in the documentation and/or other materials provided   with the distribution, and 3. Redistributions must contain a verbatim copy of this document. The OpenLDAP Foundation may revise this license from time to time. Each revision is distinguished by a version number.  You may use this Software under terms of this license revision or under the terms of any subsequent revision of the license. THIS SOFTWARE IS PROVIDED BY THE OPENLDAP FOUNDATION AND ITS CONTRIBUTORS ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OPENLDAP FOUNDATION, ITS CONTRIBUTORS, OR THE AUTHOR(S) OR OWNER(S) OF THE SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. The names of the authors and copyright holders must not be used in advertising or otherwise to promote the sale, use or other dealing in this Software without specific, written prior permission.  Title to copyright in this Software shall at all times remain with copyright holders. OpenLDAP is a registered trademark of the OpenLDAP Foundation. Copyright 1999-2003 The OpenLDAP Foundation, Redwood City, California, USA.  All Rights Reserved.  Permission to copy and distribute verbatim copies of this document is granted.
 
-# Documentation
+## Documentation
 
-## Overview
+:point_right:
+[**Documentation**](documentation.md)
 
-LDAP is a vendor neutral protocol to gain interaction with directory services. The open protocol that client/servers should implement is detailed on [RFC 4511](https://docs.ldap.com/specs/rfc4511.txt).
 
-The protocol is often used by organizations for centralized authentication and storage of their resources such as users, groups, services, applications, etc. For example, a client application can find if a user is a member of a particular group to allow access to their service.
+<!-- FIXME
 
-The KDB+ interface for LDAP uses [OpenLDAP](https://openldap.org/), which has client libraries and server implementations.  Not all server vendors may provide the same set of features, so this API aims to be vendor neutral to gain maximum flexibility.
+is in the :open_file_folder: [`docs`](docs) folder.
 
-## Function Reference
-
-### .ldap.init
-
-Initializes the session with LDAP server connection details. Connection will occur on first operation. Does not create a connection. Use unbind to free the session. Reference [ldap_initialize](https://www.openldap.org/software/man.cgi?query=ldap_init&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release)
-
-Syntax: `.ldap.init[sess;uris]`
-
-Where
-
-- sess is an int/long that you will use to track the session in subsequent calls. Should be a unique number for each session you wish to initialize. The number can only be reused to refer to a session after a .ldap.unbind.
-- uris is a symbol list. Each URI in the list must follow the format of schema://host:port , where schema is 'ldap','ldaps','ldapi', or 'cldap'.
-
-Returns 0 if successful.
-
-### .ldap.setOption
-
-Sets options per session that affect LDAP operating procedures. Reference [ldap_set_option](https://www.openldap.org/software/man.cgi?query=ldap_set_option&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release)
-
-Syntax: `.ldap.setOption[sess;option;value]`
-
-Where
-
-- sess is an int/long that represents the session previously created via .ldap.init
-- option is a symbol for the option you wish to set. See supported options below.
-- value is the value relating to the option. The data type depends on the option selected (see below)
-
-Supported LDAP options
-
-- LDAP_OPT_CONNECT_ASYNC (value data type int/long)
-- LDAP_OPT_DEBUG_LEVEL (value data type int/long)
-- LDAP_OPT_DEREF (value can be .ldap.LDAP_DEREF_NEVER, .ldap.LDAP_DEREF_SEARCHING, .ldap.LDAP_DEREF_FINDING or .ldap.LDAP_DEREF_ALWAYS)
-- LDAP_OPT_DIAGNOSTIC_MESSAGE (value data type string/symbol)
-- LDAP_OPT_NETWORK_TIMEOUT (value data type int/long - representing microseconds)
-- LDAP_OPT_MATCHED_DN (value data type string/symbol)
-- LDAP_OPT_PROTOCOL_VERSION (value data type int/long)
-- LDAP_OPT_REFERRALS (value can be .ldap.LDAP_OPT_ON or .ldap.LDAP_OPT_OFF)
-- LDAP_OPT_RESULT_CODE (value data type int/long)
-- LDAP_OPT_SIZELIMIT (value data type int/long)
-- LDAP_OPT_TIMELIMIT (value data type int/long)
-- LDAP_OPT_TIMEOUT (value data type int/long - representing microseconds)
-
-Supported SASL options
-
-- LDAP_OPT_X_SASL_MAXBUFSIZE (value data type long)
-- LDAP_OPT_X_SASL_NOCANON (value data type int/long)
-- LDAP_OPT_X_SASL_SECPROPS (value data type string/symbol)
-- LDAP_OPT_X_SASL_SSF_EXTERNAL (value data type long)
-- LDAP_OPT_X_SASL_SSF_MAX (value data type long)
-- LDAP_OPT_X_SASL_SSF_MIN (value data type long)
-
-Supported TCP options
-
-- LDAP_OPT_X_KEEPALIVE_IDLE (value data type int/long)
-- LDAP_OPT_X_KEEPALIVE_PROBES (value data type int/long)
-- LDAP_OPT_X_KEEPALIVE_INTERVAL (value data type int/long)
-
-Supported TLS options
-
-- LDAP_OPT_X_TLS_CACERTDIR (value data type string/symbol)
-- LDAP_OPT_X_TLS_CACERTFILE (value data type string/symbol)
-- LDAP_OPT_X_TLS_CERTFILE (value data type string/symbol)
-- LDAP_OPT_X_TLS_CIPHER_SUITE (value data type string/symbol)
-- LDAP_OPT_X_TLS_CRLCHECK (value data type int/long)
-- LDAP_OPT_X_TLS_CRLFILE (value data type string/symbol)
-- LDAP_OPT_X_TLS_DHFILE (value data type string/symbol)
-- LDAP_OPT_X_TLS_KEYFILE (value data type string/symbol)
-- LDAP_OPT_X_TLS_NEWCTX (value data type int/long)
-- LDAP_OPT_X_TLS_PROTOCOL_MIN (value data type int/long)
-- LDAP_OPT_X_TLS_RANDOM_FILE (value data type string/symbol)
-- LDAP_OPT_X_TLS_REQUIRE_CERT (value data type int/long)
-
-### .ldap.setGlobalOption
-
-Sets options globally that affect LDAP operating procedures. LDAP handles inherit their default settings from the global options in       effect at the time the handle is created (i.e. if a global setting is made, all sessions initialized after that will inherit those settings but not any sessions created prior). Reference .ldap.setOption for params & details.
-
-Syntax: `.ldap.setGlobalOption[option;value]`
-
-### .ldap.getOption
-
-Gets session options that affect LDAP operating procedures. Reference [ldap_set_option](https://www.openldap.org/software/man.cgi?query=ldap_set_option&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release)
-
-Syntax: `.ldap.getOption[sess;option]`
-
-Where
-
-- sess is an int/long that represents the session previously created via .ldap.init
-- option is a symbol for the option you wish to get. See supported options below
-
-Value returned from function depends on options used. Supported LDAP options
-
-- LDAP_OPT_API_FEATURE_INFO (returns dict containing feature version info - subset of LDAP_OPT_API_INFO)
-- LDAP_OPT_API_INFO (returns dict containing API version info)
-- LDAP_OPT_CONNECT_ASYNC (returns int)
-- LDAP_OPT_DEBUG_LEVEL (returns int)
-- LDAP_OPT_DEREF (returns int)
-- LDAP_OPT_DESC (returns int)
-- LDAP_OPT_DIAGNOSTIC_MESSAGE (returns string)
-- LDAP_OPT_MATCHED_DN (returns string)
-- LDAP_OPT_NETWORK_TIMEOUT (return int representing microseconds)
-- LDAP_OPT_PROTOCOL_VERSION (returns int)
-- LDAP_OPT_REFERRALS (returns int)
-- LDAP_OPT_RESULT_CODE (returns int)
-- LDAP_OPT_SIZELIMIT (returns int)
-- LDAP_OPT_TIMELIMIT (returns int)
-- LDAP_OPT_TIMEOUT (return int representing microseconds)
-
-Supported SASL options
-
-- LDAP_OPT_X_SASL_AUTHCID (returns string)
-- LDAP_OPT_X_SASL_AUTHZID (returns string)
-- LDAP_OPT_X_SASL_MAXBUFSIZE (returns long)
-- LDAP_OPT_X_SASL_MECH (returns string)
-- LDAP_OPT_X_SASL_MECHLIST (returns string)
-- LDAP_OPT_X_SASL_NOCANON (returns int)
-- LDAP_OPT_X_SASL_REALM (returns string)
-- LDAP_OPT_X_SASL_SSF (returns long)
-- LDAP_OPT_X_SASL_SSF_MAX (returns long)
-- LDAP_OPT_X_SASL_SSF_MIN (returns long)
-- LDAP_OPT_X_SASL_USERNAME (returns string)
-
-Supported TCP options
-
-- LDAP_OPT_X_KEEPALIVE_IDLE (returns int)
-- LDAP_OPT_X_KEEPALIVE_PROBES (returns int)
-- LDAP_OPT_X_KEEPALIVE_INTERVAL (returns int)
-
-Supported TLS options
-
-- LDAP_OPT_X_TLS_CACERTDIR (returns string)
-- LDAP_OPT_X_TLS_CACERTFILE (returns string)
-- LDAP_OPT_X_TLS_CERTFILE (returns string)
-- LDAP_OPT_X_TLS_CIPHER_SUITE (returns string)
-- LDAP_OPT_X_TLS_CRLCHECK (returns int)
-- LDAP_OPT_X_TLS_CRLFILE (returns string)
-- LDAP_OPT_X_TLS_DHFILE (returns string)
-- LDAP_OPT_X_TLS_KEYFILE (returns string)
-- LDAP_OPT_X_TLS_PROTOCOL_MIN (returns int)
-- LDAP_OPT_X_TLS_RANDOM_FILE (returns string)
-- LDAP_OPT_X_TLS_REQUIRE_CERT (returns int)
-
-### .ldap.getGlobalOption
-
-Gets options globally that affect LDAP operating procedures. Reference .ldap.getOption for details and parameter details
-
-Syntax: `.ldap.getGlobalOption[option]`
-
-### .ldap.startTLS
-
-Using ldaps:// (with the appropriate TLS/SSL options) will perform the TLS handshake automatically on connection.
-An alternative is to use `.ldap.startTLS`  for initialising a TLS handshake on a normal ldap connection (calls [ldap_start_tls_s](https://linux.die.net/man/3/ldap_start_tls_s))
-
-`.ldap.startTLS` sends a StartTLS request to a server, waits for the reply, and then installs TLS handlers on the session if the request succeeded. The routine returns LDAP_SUCCESS if everything succeeded, otherwise it returns an LDAP error code.
-
-Syntax: `.ldap.startTLS[sess]`
-
-### .ldap.bind
-
-Synchronous bind operations are used to authenticate clients (and the users or applications behind them) to the directory server, to establish an authorization identity that will be used for subsequent operations processed on that connection, and to specify the LDAP protocol version that the client will use. See [here](https://ldap.com/the-ldap-bind-operation/) for reference documentation
-
-Syntax: `.ldap.bind[sess;dn;cred;mech]`
-
-Where
-
-- sess is an int/long that represents the session previously created via .ldap.init
-- dn is a string/symbol. The DN of the user to authenticate. This should be an empty string/symbol or generic null for anonymous simple authentication, and is typically empty for SASL authentication because most SASL mechanisms identify the target account in the encoded credentials. It must be non-empty for non-anonymous simple authentication.
-- cred is a char/byte array or symbol. LDAP credentials (e.g. password). Pass empty string/symbol or generic null when no password required for connection.
-- mech is a string/symbol. Pass an empty string or generic null to use the default LDAP_SASL_SIMPLE mechanism. Query the attribute 'supportedSASLMechanisms' from the  server's rootDSE for the list of SASL mechanisms the server supports.
-
-Returns a dict consisting of 
-
-- ReturnCode - integer. See error code reference  within this document.
-- Credentials - byte array which is the credentials returned by the server. Contents are empty for LDAP_SASL_SIMPLE, though for other SASL mechanisms, the credentials may need to be used with other security related functions (which may be external to LDAP). Reference documentation for your security mechanism.
-
-#### Using Security Mechanisms
-
-LDAP supports a range of security mechanisms as part of the bind call. Check with your LDAP server/admin what is supported (often found in the root attribute named 'supportedSASLMechanisms').
-
-Most of the security mechanisms are performed externally, in separate code related to your security mechanism.
-
-For example,  DIGEST_MD5 is initially performed by calling bind with no credentials, mech set to "DIGEST-MD5" & capturing the returned credential values from the server. Using the returned credentials to MD5 encode the user details, a second bind call is then made with the MD5 encoded details as the 'cred' parameter. This requires an additional MD5 library that is outside the scope of this interface (Ref: [example code)](https://github.com/zheolong/melody-lib/blob/master/libldap5/sources/ldap/common/digest_md5.c). Other security mechanisms may operate in a similar manner (e.g. [GSSAPI](https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface) example [here](https://github.com/hajuuk/R7000/blob/master/ap/gpl/samba-3.0.13/source/libads/sasl.c), [CRAM-MD5](https://en.wikipedia.org/wiki/CRAM-MD5) available [here](https://github.com/illumos/illumos-gate/blob/master/usr/src/lib/libldap5/sources/ldap/common/cram_md5.c)).
-
-### .ldap.search
-
-Synchronous search for partial or complete copies of entries based on a search criteria.
-
-Syntax: .ldap.search_s[sess;baseDn;scope;filter;attrs;attrsOnly;timeLimit;sizeLimit]
-
-Where
-
-- sess is an int/long that represents the session previously created via .ldap.init
-- baseDn is a string/symbol. The base of the subtree to search from. An empty string/symbol or generic null can be used to search from the root (or when a DN is not known).
-- scope  is an int/long. Can be set to one of the following values:
-  - 0 (LDAP_SCOPE_BASE) Only the entry specified will be considered in the search & no subordinates used
-  - 1 (LDAP_SCOPE_ONELEVEL) Only search the immediate children of entry specified. Will not use the entry specified or further subordinates from the children.
-  - 2 (LDAP_SCOPE_SUBTREE) To search the entry and all subordinates
-  - 3 (LDAP_SCOPE_CHILDREN) To search all of the subordinates
-- filter is a string/symbol. The filter to be applied to the search ([reference](https://ldap.com/ldap-filters/))
-- attrs is a symbol list. The set of attributes to include in the result. If a specific set of attribute descriptions are listed, then only those attributes should be included in matching entries. The special value “*” indicates that all user attributes should be included in matching entries. The special value “+” indicates that all operational attributes should be included in matching entries. The special value “1.1” indicates that no attributes should be included in matching entries. Some servers may also support the ability to use the “@” symbol followed by an object class name (e.g., “@inetOrgPerson”) to request all attributes associated with that object class. If the set of attributes to request is an empty symbol/string or generic null, then the server should behave as if the value “*” was specified to request that all user attributes be included in entries that are returned.
-- attrsOnly is an int/long. Should be set to a non-zero value if only attribute descriptions are wanted. It should be set to zero (0) if both attributes descriptions and attribute values are wanted.
-- timeLimit is an int/long. Max number of microseconds to wait for a result. 0 represents no limit. Note that the server may impose its own limit.
-- sizeLimit is an int/long. Max number of entries to use in the result. 0 represents no limit. Note that the server may impose its own limit.
-
-Returns a dict consisting of 
-
-- ReturnCode - integer. See error code reference within this document
-- Entries - table consisting of DNs and Attributes. Attribute forms a dictionary, were each attribute may contain one or more values.
-- Referrals - list of strings providing the referrals that can be searched to gain access to the required info (if server supports referrals)
-
-### .ldap.unbind
-
-Synchronous unbind from the directory, terminate the current association, and free resources. Should be called even if a session did not bind (or failed to bind), but initialized its session.
-
-Syntax: `.ldap.unbind[sess]`
-
-Where 
-
-- sess is an int/long that represents the session previously created via .ldap.init. The number should no longer be used unless .ldap.init and .ldap.bind_s has been used to create a new session.
-
-### .ldap.err2string
-
-Returns a string description of an LDAP error code. The error codes are negative for an API error, 0 for success, and positive for a LDAP result code
-
-Syntax: `.ldap.err2string[err]`
-
-Where 
-
-- err is an ldap error code (see error code reference  within this document)
-
-## Error Code Reference
-
-The function .ldap.err2string call can provide a string representation of the error code.
-
-0 = Success
-
-### Protocol Codes
-
-These are all positive values. Reference IANA registered result codes [here](https://www.iana.org/assignments/ldap-parameters/ldap-parameters.xhtml#ldap-parameters-6)
-
-### API Error Codes
-
-These are all negative values.
-
-| Code | Name                         | Details                                                      |
-| ---- | ---------------------------- | ------------------------------------------------------------ |
-| -1   | LDAP_SERVER_DOWN             | The LDAP library can't contact the LDAP server.              |
-| -2   | LDAP_LOCAL_ERROR             | Some local  error  occurred.   This  is  usually  a failed dynamic memory allocation. |
-| -3   | LDAP_ENCODING_ERROR          | An  error  was  encountered  encoding parameters to send to the LDAP server. |
-| -4   | LDAP_DECODING_ERROR          | An error was encountered decoding a result from the LDAP server. |
-| -5   | LDAP_TIMEOUT                 | A  timelimit  was  exceeded  while  waiting  for  a result.  |
-| -6   | LDAP_AUTH_UNKNOWN            | The authentication method specified to  ldap_bind()  is not known. |
-| -7   | LDAP_FILTER_ERROR            | An  invalid  filter  was  supplied to ldap_search() (e.g., unbalanced parentheses). |
-| -8   | LDAP_USER_CANCELLED          | Indicates the user cancelled the operation.                  |
-| -9   | LDAP_PARAM_ERROR             | An ldap routine was called with a bad parameter.             |
-| -10  | LDAP_NO_MEMORY               | An memory  allocation  (e.g.,  [malloc(3)](https://www.openldap.org/software/man.cgi?query=malloc&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release)  or  other  dynamic  memory  allocator)  call failed in an ldap library routine. |
-| -11  | LDAP_CONNECT_ERROR           | Indicates a connection problem.                              |
-| -12  | LDAP_NOT_SUPPORTED           | Indicates the routine was called in  a  manner  not supported by the library. |
-| -13  | LDAP_CONTROL_NOT_FOUND       | Indicates  the  control  provided is unknown to the client library. |
-| -14  | LDAP_NO_RESULTS_RETURNED     | Indicates no results returned.                               |
-| -16  | LDAP_CLIENT_LOOP             | Indicates the library has detected a  loop  in  its processing. |
-| -17  | LDAP_REFERRAL_LIMIT_EXCEEDED | Indicates the referral limit has been exceeded.              |
-| -18  | LDAP_X_CONNECTING            | Indicates async connect attempt is ongoing.                  |
-
-
+ -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# LDAP interface for kdb+
+
+<!-- FIXME Merge with contents of ../README.md and ../documentation.md -->
+
+
+Lightweight Directory Access Protocol(LDAP) is a vendor-neutral protocol to interact with directory services. The open protocol that client/servers should implement is detailed on [RFC 4511](https://docs.ldap.com/specs/rfc4511.txt).
+
+The protocol is often used by organizations for centralized authentication and storage of their resources such as users, groups, services, applications, etc. For example, a client application can find if a user is a member of a particular group to allow access to their service.
+
+
+## Use cases
+
+In addition to authentication and authorization uses, depending on the data stored on your LDAP server, it could be used to access data for analytics e.g.
+
+-   company staff turnover (if user creation date/leave dates/etc. recorded)
+-   IT equipment approaching end of life (if hardware details recorded)
+-   staff departmental memberships
+
+
+## Kdb+/LDAP integration
+
+This interface allows kdb+ to interact with the LDAP. This API permits a client to authenticate and search against an LDAP server. The interface is a thin wrapper against the open source [OpenLDAP](https://openldap.org/) library. 
+
+:globe_with_meridians:
+[LDAP API manual](https://www.openldap.org/software/man.cgi?query=ldap&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release "www.openldap.org")
+
+Not all server vendors may provide the same set of features, so this API aims to be vendor-neutral for maximum flexibility.
+
+
+[Install guide](https://github.com/KxSystems/ldap#installation)
+
+
+## Status
+
+The interface is currently available as a beta version under an Apache 2.0 licence and is supported on a best-efforts basis by the Fusion team. 
+This interface is currently in active development, with additional functionality to be released on an ongoing basis.
+
+[Issues and feature requests](https://github.com/KxSystems/ldap/issues) 
+<br>
+[Guide to contributing](https://github.com/KxSystems/ldap/blob/master/CONTRIBUTING.md)
+
+

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,40 @@
+# LDAP interface examples
+
+
+
+The scripts below are in the `examples` folder of the [interface](https://github.com/KxSystems/ldap/tree/master/examples). 
+They provide insight into the different capabilities of the interface.
+
+## Requirements
+
+1. The LDAP interface installed as described in the interface’s [`README.md`](https://github.com/kxsystems/ldap/blob/master/README.md)
+2. The folder `q/` containing `ldap.q` placed either in the examples folder or (preferably) in the your `QHOME` directory.
+
+
+## Root DSE query
+
+Queries the server’s `rootDSE`. Depending on the functionality your server supports, and its config, it may show attributes such as `supportedSASLMechanisms` (supported security mechanisms for use in bind). 
+
+:globe_with_meridians:
+[Other attributes that may be populated](https://ldapwiki.com/wiki/RootDSE "ldapwiki.com") 
+
+The `rootDSE` is often used to discover what functionality an LDAP server may support, and information to identify the type of LDAP server, e.g. vendor details. The `rootDSE` may be subject to access restrictions, so your server may require you to do a specific bind to retrieve these details.
+
+The connection details within the script may need altering to communicate with your LDAP server.
+
+```bash
+q root_dse.q
+```
+
+## Search
+
+Shows a search that works with the example LDAP server at: 
+
+[rroemhild/docker-test-openldapi](https://github.com/rroemhild/docker-test-openldap)
+
+The script includes searches such as searching for a user’s email. 
+(This example server does not require a bind with user dn/password.)
+
+```bash
+q search.q
+```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,526 @@
+# LDAP function reference
+
+`.ldap.`   **LDAP interface**
+
+[`bind`](#ldapbind)             Synchronous bind to authenticate client<br>
+[`err2string`](#ldaperr2string)       String description of an LDAP error code<br>
+[`getGlobalOption`](#ldapgetglobaloption)  Get global LDAP option<br>
+[`getOption`](#ldapgetoption)        Get session LDAP option<br>
+[`init`](#ldapinit)             Initialize session with LDAP server connection details<br>
+[`search`](#ldapsearch)           Synchronous search for partial or complete copies of entries<br>
+[`setOption`](#ldapsetoption)        Set session LDAP option<br>
+[`setGlobalOption`](#ldapsetglobaloption)  Set global LDAP option<br>
+[`unbind`](#ldapunbind)           Synchronous unbind from the directory
+
+
+
+## `.ldap.bind`
+
+_Synchronous bind to authenticate client_
+
+```txt
+.ldap.bind[sess;opts]
+```
+
+Where
+
+-   `sess` is an int or long that represents the session previously created via `.ldap.init`
+-   `opts` is a generic null or a dictionary of non-default options for the bind operation
+
+binds to the session and returns a result code and server credentials as a dictionary.
+
+Synchronous bind operations are used to authenticate clients (and the users or applications behind them) to the directory server, to establish an authorization identity that will be used for subsequent operations processed on that connection, and to specify the LDAP protocol version that the client will use.
+
+:globe_with_meridians:
+[The LDAP bind operation](https://ldap.com/the-ldap-bind-operation/)
+
+Valid `opts` entries:
+
+name | type | content | default
+-----|------|---------|--------
+`dn` | string or symbol | user to authenticate | Anonymous simple authentication. (Typical for SASL authentication as most SASL mechanisms identify the target account within the encoded credentials.)
+`cred` | char/byte list or symbol | LDAP credentials, e.g. password | Assume no password required.
+`mech` | string or symbol | SASL mechanism for authentication | `LDAP_SASL_SIMPLE`<br><br>Query the attribute `supportedSASLMechanisms` from the  server’s `rootDSE` for the list of SASL mechanisms the server supports.
+
+Result dictionary:
+
+key         | type       | content
+------------|------------|-----------------
+`ReturnCode`  | integer    | [result code](#result-codes)
+`Credentials` | byte array | credentials returned by the server<br><br>Empty for `LDAP_SASL_SIMPLE`; for other SASL mechanisms, the credentials may need to be used with other security-related functions, which may be external to LDAP.
+
+:point_right:
+[Security mechanisms](#security-mechanisms)
+
+```q
+// Complete a default bind to the server
+q).ldap.bind[0i;::]
+ReturnCode | 0i
+Credentials| `byte$()
+
+// Complete a bind to the server with non default parameters
+q).ldap.bind[0i;enlist[`dn]!enlist `Tom]
+ReturnCode | 0i
+Credentials| `byte$()
+```
+
+
+## `.ldap.err2string`
+
+_String description of an LDAP result code_
+
+```txt
+.ldap.err2string[err]
+```
+
+Where `err` is an integer LDAP result code, returns its string representation.
+
+Result codes are negative for an API error, 0 for success, and positive for a LDAP error.
+
+:point_right:
+[Result codes](#result-codes)
+
+```q
+q).ldap.err2string[0]
+"Success"
+q).ldap.err2string[-9]
+"Bad parameter to an ldap routine"
+q).ldap.err2string[5]
+"Compare False"
+```
+
+
+## `.ldap.getGlobalOption`
+
+_Get global LDAP option_
+
+```txt
+.ldap.getGlobalOption[option]
+```
+
+Where `option` (symbol) is the option to get, returns [its value](#get-options).
+
+```q
+q).ldap.getGlobalOption[`LDAP_OPT_PROTOCOL_VERSION]
+,3
+q).ldap.getGlobalOption[`LDAP_OPT_X_TLS_REQUIRE_CERT]
+,3
+```
+
+
+## `.ldap.getOption`
+
+_Get session LDAP option_
+
+```txt
+.ldap.getOption[sess;option]
+```
+
+Where
+
+-   `sess` (int or long) is the session previously created with `.ldap.init`
+-   `option` (symbol) is the [option](#get-options) to get
+
+returns the [value for `option`](#get-options).
+
+```q
+q).ldap.getOption[0i;`LDAP_OPT_PROTOCOL_VERSION]
+,3
+q).ldap.getOption[0i;`LDAP_OPT_NETWORK_TIMEOUT]
+30000
+```
+
+:globe_with_meridians:
+[`ldap_set_option`](https://www.openldap.org/software/man.cgi?query=ldap_set_option&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release)
+
+
+## `.ldap.init`
+
+_Initialize the session with LDAP server connection details_
+
+```txt
+.ldap.init[sess;uris]
+```
+
+Where
+
+-   `sess` (int or long) is the session ID: unique for each session you initialize
+-   `uris` (symbol list) URIs in the format `schema://host:port`
+
+returns `0i` if successful, otherwise an LDAP error code.
+
+Values for `schema`: `ldap`, `ldaps`, `ldapi` or `cldap`.
+
+Connection occurs on first operation: `init` does not create a connection.
+
+Use [`unbind`](#ldap-unbind) to free the session, after which the session ID can be reused.
+
+:globe_with_meridians:
+[`ldap_initialize`](https://www.openldap.org/software/man.cgi?query=ldap_init&sektion=3&apropos=0&manpath=openldap+2.4-release "www.openldap.org")
+
+
+```q
+// successfully execute initialization
+q).ldap.init[0i;enlist `$"ldap://0.0.0.0:389"]
+0i
+
+// attempt to initialize with an incorrect 'schema'
+q).ldap.init[1i;enlist `$"noldap://0.0.0.0:389"]
+-9i
+
+// retrieve error message for above error code
+q).ldap.err2string[-9i]
+"Bad parameter to an ldap routine"
+```
+
+
+## `.ldap.search`
+
+_Synchronous search for partial or complete copies of entries_
+
+```txt
+.ldap.search[sess;scope;filter;opts]
+```
+
+Where
+
+-   `sess` (int or long) is a session ID previously created with [`.ldap.init`](#ldap-init)
+-   `scope` (int long) is the [scope of the search](#scope)
+-   `filter` (string or symbol) is the [filter to be applied](https://ldap.com/ldap-filters/ "ldap.com")
+-   `opts` is the generic null or a dictionary of non-default options for the search
+
+returns results as a dictionary.
+
+Search options (`opts`):
+
+name | type | content | default
+-----|------|---------|--------
+`baseDn` | string or symbol | base of the subtree to search from | search from the root (or when a DN is not known)
+`attr` | symbol list | attributes to include in the result | `*` (all user attributes)
+`attrsOnly` | int or long | return both attribute descriptions and values unless +ve, when return only descriptions | both
+`timeLimit` | int or long | number of microseconds to wait for a result | 0 (no limit)<br><br>The server may impose its own limit.
+`sizeLimit` | int or long | max number of entries to return | 0 (no limit)<br><br>The server may impose its own limit.
+
+Special `attr` values: include in results
+```txt
+*     all user attributes
++     all operational attributes
+1.1   no attributes
+```
+
+Some servers may also support the ability to use the `@` symbol followed by an object class name (e.g. `@inetOrgPerson`) to request all attributes associated with that object class.
+
+Result dictionary:
+
+key           | type    | explanation
+--------------|---------|-----------------
+`ReturnCode`  | integer | [result code](#result-codes)
+`Entries`     | table   | DNs and attribute dictionaries
+`Referrals`   | list    | list of strings providing the referrals that can be searched to gain access to the required info (if server supports referrals)
+
+```q
+// Run a blind/default search at base level
+q)session:0i
+q)scope  :.ldap.LDAP_SCOPE_BASE
+q)filter :"(objectClass=*)"
+q).ldap.search[session;scope;filter;::]
+ReturnCode| 0i
+Entries   | +`DN`Attributes!(,"";,(,`objectClass)!,("top";"OpenLDAProotDSE"))
+Referrals | ()
+
+// Run a non default search
+q)session:0i
+q)scope  :.ldap.LDAP_SCOPE_SUBTREE
+q)filter :"(cn=Amy Wong)"
+q)options:`baseDN`attr!(`$"ou=people,dc=planetexpress,dc=com";`mail`givenName)
+q).ldap.search[session;scope;filter;options]
+ReturnCode| 0i
+Entries   | +`DN`Attributes!(,"cn=Amy Wong+sn=Kroker,ou=people,dc=planetexpress,dc=com";,`givenName`mail!(,"Amy";,"amy@planetexpress.com"))
+Referrals | ()
+```
+
+
+## `.ldap.setGlobalOption`
+
+_Set global LDAP option_
+
+```txt
+.ldap.setGlobalOption[option;value]
+```
+
+Where
+
+-   `option` (symbol) is the [option](#set-options) to set
+-   `value` is the [value](#set-options) to set for it
+
+returns `0i` if successful, otherwise an [LDAP error code](#ldap-errors).
+
+```q
+q).ldap.setGlobalOption[0i;`LDAP_OPT_X_TLS_REQUIRE_CERT;3]
+0i
+q).ldap.setGlobalOption[0i;`LDAP_OPT_NETWORK_TIMEOUT ;30000]
+0i
+```
+
+LDAP handles inherit their default settings from the global options in effect at the time the handle is created, i.e. if a global setting is made, all sessions initialized after that will inherit those settings but not any sessions created prior.
+
+
+## `.ldap.setOption`
+
+_Set session LDSAP option_
+
+```txt
+.ldap.setOption[sess;option;value]
+```
+
+Where
+
+-   `sess` (int or long) is the session ID created with `.ldap.init`
+-   `option` (symbol) is the [option](#set-options) to set
+-   `value` is the [value](#set-options) to set for that option
+
+returns `0i` if successful, otherwise an [LDAP error code](#ldap-errors).
+
+:globe_with_meridians:
+[`ldap_set_option`](https://www.openldap.org/software/man.cgi?query=ldap_set_option&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release "www.openldap.org")
+
+```q
+q).ldap.setOption[0i;`LDAP_OPT_PROTOCOL_VERSION;3]
+0i
+q).ldap.setOption[0i;`LDAP_OPT_NETWORK_TIMEOUT ;30000]
+0i
+```
+
+
+## `.ldap.unbind`
+
+_Synchronous unbind from the directory, terminate the current association, and free resources_
+
+```txt
+.ldap.unbind[sess]
+```
+
+Where `sess` (int or long) is the session ID created with `.ldap.init`, returns `0i` if successful, otherwise a LDAP error code.
+
+> Tip: Invoke even if a session did not bind (or failed to bind), but had been initialized.
+
+The session ID can be re-used when subsequently creating a new session with `.ldap.init`.
+
+```q
+q).ldap.unbind[0i]
+0i
+```
+
+
+## Scope
+
+```txt
+LDAP_SCOPE_BASE      0  the specified entry and no subordinates
+LDAP_SCOPE_ONELEVEL  1  immediate children of the specified entry;
+                        not the entry itself, nor further subordinates
+LDAP_SCOPE_SUBTREE   2  the specified entry and all subordinates
+LDAP_SCOPE_CHILDREN  3  all of the subordinates
+```
+
+## Get options
+
+Options are listed by protocol.
+
+:globe_with_meridians:
+[`ldap_get_option`](https://www.openldap.org/software/man.cgi?query=ldap_get_option&apropos=0&sektion=3&manpath=OpenLDAP+2.4-Release&arch=default&format=html "www.openldap.org")
+
+
+### `LDAP`
+
+```txt
+LDAP_OPT_API_FEATURE_INFO     dictionary
+LDAP_OPT_API_INFO             dictionary
+LDAP_OPT_CONNECT_ASYNC        integer
+LDAP_OPT_DEBUG_LEVEL          integer
+LDAP_OPT_DEREF                integer
+LDAP_OPT_DESC                 integer
+LDAP_OPT_DIAGNOSTIC_MESSAGE   string
+LDAP_OPT_MATCHED_DN           string
+LDAP_OPT_NETWORK_TIMEOUT      integer        timeout in microseconds
+LDAP_OPT_PROTOCOL_VERSION     integer
+LDAP_OPT_REFERRALS            integer
+LDAP_OPT_RESULT_CODE          integer
+LDAP_OPT_SIZELIMIT            integer
+LDAP_OPT_TIMELIMIT            integer
+LDAP_OPT_TIMEOUT              integer        timeout in microseconds
+```
+
+
+### `SASL`
+
+```txt
+LDAP_OPT_X_SASL_AUTHCID      string
+LDAP_OPT_X_SASL_AUTHZID      string
+LDAP_OPT_X_SASL_MAXBUFSIZE   long
+LDAP_OPT_X_SASL_MECH         string
+LDAP_OPT_X_SASL_MECHLIST     string
+LDAP_OPT_X_SASL_NOCANON      integer
+LDAP_OPT_X_SASL_REALM        string
+LDAP_OPT_X_SASL_SSF          long
+LDAP_OPT_X_SASL_SSF_MAX      long
+LDAP_OPT_X_SASL_SSF_MIN      long
+LDAP_OPT_X_SASL_USERNAME     string
+```
+
+
+### `TCP`
+
+```txt
+LDAP_OPT_X_KEEPALIVE_IDLE      integer
+LDAP_OPT_X_KEEPALIVE_PROBES    integer
+LDAP_OPT_X_KEEPALIVE_INTERVAL  integer
+```
+
+
+### `TLS`
+
+```txt
+LDAP_OPT_X_TLS_CACERTDIR      string
+LDAP_OPT_X_TLS_CACERTFILE     string
+LDAP_OPT_X_TLS_CERTFILE       string
+LDAP_OPT_X_TLS_CIPHER_SUITE   string
+LDAP_OPT_X_TLS_CRLCHECK       integer
+LDAP_OPT_X_TLS_CRLFILE        string
+LDAP_OPT_X_TLS_DHFILE         string
+LDAP_OPT_X_TLS_KEYFILE        string
+LDAP_OPT_X_TLS_PROTOCOL_MIN   integer
+LDAP_OPT_X_TLS_RANDOM_FILE    string
+LDAP_OPT_X_TLS_REQUIRE_CERT   integer
+```
+
+
+## Set options
+
+The options are listed by protocol.
+
+:globe_with_meridians:
+[`ldap_set_option`](https://www.openldap.org/software/man.cgi?query=ldap_set_option&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release "www.openldap.org")
+
+
+### `LDAP`
+
+```txt
+LDAP_OPT_CONNECT_ASYNC       integer/long
+LDAP_OPT_DEBUG_LEVEL         integer/long
+LDAP_OPT_DEREF               integer/long    one of: .ldap.LDAP_DEREF_NEVER
+                                                     .ldap.LDAP_DEREF_SEARCHING
+                                                     .ldap.LDAP_DEREF_FINDING
+                                                     .ldap.LDAP_DEREF_ALWAYS
+LDAP_OPT_DIAGNOSTIC_MESSAGE  string/symbol
+LDAP_OPT_NETWORK_TIMEOUT     integer/long    number of microseconds for timeout
+LDAP_OPT_MATCHED_DN          string/symbol
+LDAP_OPT_PROTOCOL_VERSION    integer/long
+LDAP_OPT_REFERRALS           integer/long    .ldap.LDAP_OPT_ON or .ldap.LDAP_OPT_OFF
+LDAP_OPT_RESULT_CODE         integer/long
+LDAP_OPT_SIZELIMIT           integer/long
+LDAP_OPT_TIMELIMIT           integer/long
+LDAP_OPT_TIMEOUT             integer/long    number of microseconds for timeout
+```
+
+
+### `SASL`
+
+```txt
+LDAP_OPT_X_SASL_MAXBUFSIZE    long
+LDAP_OPT_X_SASL_NOCANON       integer/long
+LDAP_OPT_X_SASL_SECPROPS      string/symbol
+LDAP_OPT_X_SASL_SSF_EXTERNAL  long
+LDAP_OPT_X_SASL_SSF_MAX       long
+LDAP_OPT_X_SASL_SSF_MIN       long
+```
+
+
+### `TCP`
+
+```txt
+LDAP_OPT_X_KEEPALIVE_IDLE      integer/long
+LDAP_OPT_X_KEEPALIVE_PROBES    integer/long
+LDAP_OPT_X_KEEPALIVE_INTERVAL  integer/long
+```
+
+
+### `TLS`
+
+```txt
+LDAP_OPT_X_TLS_CACERTDIR      string/symbol
+LDAP_OPT_X_TLS_CACERTFILE     string/symbol
+LDAP_OPT_X_TLS_CERTFILE       string/symbol
+LDAP_OPT_X_TLS_CIPHER_SUITE   string/symbol
+LDAP_OPT_X_TLS_CRLCHECK       integer/long
+LDAP_OPT_X_TLS_CRLFILE        string/symbol
+LDAP_OPT_X_TLS_DHFILE         string/symbol
+LDAP_OPT_X_TLS_KEYFILE        string/symbol
+LDAP_OPT_X_TLS_NEWCTX         integer/long
+LDAP_OPT_X_TLS_PROTOCOL_MIN   integer/long
+LDAP_OPT_X_TLS_RANDOM_FILE    string/symbol
+LDAP_OPT_X_TLS_REQUIRE_CERT   integer/long
+```
+
+
+## Result codes
+
+Code `0i` indicates success.
+
+```q
+q).ldap.err2string 0i
+"Success"
+```
+
+
+### LDAP errors
+
+LDAP error codes are positive integers.
+
+:globe_with_meridians:
+[IANA result codes](https://www.iana.org/assignments/ldap-parameters/ldap-parameters.xhtml#ldap-parameters-6 "www.iana.org")
+
+
+### API errors
+
+API error codes are negative integers.
+
+```txt
+-1  LDAP_SERVER_DOWN              LDAP library can't contact the LDAP server
+-2  LDAP_LOCAL_ERROR              local error (failed dynamic memory allocation?)
+-3  LDAP_ENCODING_ERROR           error encoding parameters for LDAP server
+-4  LDAP_DECODING_ERROR           error decoding result from the LDAP server
+-5  LDAP_TIMEOUT                  time limit exceeded waiting for a result
+-6  LDAP_AUTH_UNKNOWN             unknown authentication method specified
+-7  LDAP_FILTER_ERROR             invalid filter specified to ldap_search 
+                                  e.g. unbalanced parentheses
+-8  LDAP_USER_CANCELLED           user cancelled the operation
+-9  LDAP_PARAM_ERROR              LDAP routine called with a bad parameter
+-10 LDAP_NO_MEMORY                memory allocation call failed in LDAP library 
+                                  e.g. [malloc(3)](https://www.openldap.org/software/man.cgi?query=malloc&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release) or other dynamic memory allocator
+-11 LDAP_CONNECT_ERROR            connection problem
+-12 LDAP_NOT_SUPPORTED            routine not called as supported by the library
+-13 LDAP_CONTROL_NOT_FOUND        specified control unknown to the client library
+-14 LDAP_NO_RESULTS_RETURNED      no results returned
+-16 LDAP_CLIENT_LOOP              processing loop detected by library
+-17 LDAP_REFERRAL_LIMIT_EXCEEDED  referral limit exceeded
+-18 LDAP_X_CONNECTING             an async connect attempt is ongoing
+```
+
+
+## Security mechanisms
+
+LDAP supports a range of security mechanisms as part of the `bind` call. 
+Check with your LDAP server admin what is supported for your system. 
+
+!!! tip "Often found in the root attribute `supportedSASLMechanisms`"
+
+Most of these checks are performed externally, in separate code related to your security mechanism.
+
+For example, `DIGEST_MD5` is initially performed by calling `bind` with no credentials, `mech` set to `"DIGEST-MD5"`, and capturing the returned credential values from the server. Using the returned credentials to MD5-encode the user details, a second `bind` call is then made with the MD5-encoded details as the `cred` parameter. 
+(Requires an additional MD5 library that is outside the scope of this interface.)
+
+Examples:
+
+-   [zheolong/melody-lib](https://github.com/zheolong/melody-lib/blob/master/libldap5/sources/ldap/common/digest_md5.c) (MD5)
+-   [hajuuk/R7000](https://github.com/hajuuk/R7000/blob/master/ap/gpl/samba-3.0.13/source/libads/sasl.c) ([GSSAPI](https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface))
+-   [illumos/illumos-gate](https://github.com/illumos/illumos-gate/blob/master/usr/src/lib/libldap5/sources/ldap/common/cram_md5.c) ([CRAM-MD5](https://en.wikipedia.org/wiki/CRAM-MD5))

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -512,7 +512,7 @@ API error codes are negative integers.
 LDAP supports a range of security mechanisms as part of the `bind` call. 
 Check with your LDAP server admin what is supported for your system. 
 
-!!! tip "Often found in the root attribute `supportedSASLMechanisms`"
+> Tip: Often found in the root attribute `supportedSASLMechanisms`
 
 Most of these checks are performed externally, in separate code related to your security mechanism.
 

--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,298 @@
+# Documentation
+
+<!-- FIXME merge with conternts of docs folder -->
+
+## Overview
+
+LDAP is a vendor neutral protocol to gain interaction with directory services. The open protocol that client/servers should implement is detailed on [RFC 4511](https://docs.ldap.com/specs/rfc4511.txt).
+
+The protocol is often used by organizations for centralized authentication and storage of their resources such as users, groups, services, applications, etc. For example, a client application can find if a user is a member of a particular group to allow access to their service.
+
+The kdb+ interface for LDAP uses [OpenLdap](https://openldap.org/), which has client libraries and server implementations.  Not all server vendors may provide the same set of features, so this API aims to be vendor neutral to gain maximum flexibility.
+
+## Function reference
+
+### `.ldap.init`
+
+Initializes the session with LDAP server connection details. Connection will occur on first operation. Does not create a connection. Use unbind to free the session. Reference [ldap_initialize](https://www.openldap.org/software/man.cgi?query=ldap_init&sektion=3&apropos=0&manpath=OpenLdap+2.4-Release)
+
+```txt
+.ldap.init[sess;uris]
+```
+
+Where
+
+- `sess` is an int/long that you will use to track the session in subsequent calls. Should be a unique number for each session you wish to initialize. The number can only be reused to refer to a session after a `.ldap.unbind`.
+- `uris` is a symbol list. Each URI in the list must follow the format of schema://host:port , where schema is `ldap`,`ldaps`,`ldapi`, or `cldap`.
+
+Returns 0 if successful.
+
+### `.ldap.setOption`
+
+Sets options per session that affect LDAP operating procedures. Reference [ldap_set_option](https://www.openldap.org/software/man.cgi?query=ldap_set_option&sektion=3&apropos=0&manpath=OpenLdap+2.4-Release)
+
+```txt
+.ldap.setOption[sess;option;value]
+```
+
+Where
+
+- `sess` is an int/long that represents the session previously created via .ldap.init
+- `option` is a symbol for the option you wish to set. See supported options below.
+- `value` is the value relating to the option. The data type depends on the option selected (see below)
+
+Supported LDAP options
+
+- `LDAP_OPT_CONNECT_ASYNC` (value data type int/long)
+- `LDAP_OPT_DEBUG_LEVEL` (value data type int/long)
+- `LDAP_OPT_DEREF` (value can be `.ldap.LDAP_DEREF_NEVER`, `.ldap.LDAP_DEREF_SEARCHING`, `.ldap.LDAP_DEREF_FINDING` or `.ldap.LDAP_DEREF_ALWAYS`)
+- `LDAP_OPT_DIAGNOSTIC_MESSAGE` (value data type string/symbol)
+- `LDAP_OPT_NETWORK_TIMEOUT` (value data type int/long - representing microseconds)
+- `LDAP_OPT_MATCHED_DN` (value data type string/symbol)
+- `LDAP_OPT_PROTOCOL_VERSION` (value data type int/long)
+- `LDAP_OPT_REFERRALS` (value can be `.ldap.LDAP_OPT_ON` or `.ldap.LDAP_OPT_OFF`)
+- `LDAP_OPT_RESULT_CODE` (value data type int/long)
+- `LDAP_OPT_SIZELIMIT` (value data type int/long)
+- `LDAP_OPT_TIMELIMIT` (value data type int/long)
+- `LDAP_OPT_TIMEOUT` (value data type int/long - representing microseconds)
+
+Supported SASL options
+
+- `LDAP_OPT_X_SASL_MAXBUFSIZE` (value data type long)
+- `LDAP_OPT_X_SASL_NOCANON` (value data type int/long)
+- `LDAP_OPT_X_SASL_SECPROPS` (value data type string/symbol)
+- `LDAP_OPT_X_SASL_SSF_EXTERNAL` (value data type long)
+- `LDAP_OPT_X_SASL_SSF_MAX` (value data type long)
+- `LDAP_OPT_X_SASL_SSF_MIN` (value data type long)
+
+Supported TCP options
+
+- `LDAP_OPT_X_KEEPALIVE_IDLE` (value data type int/long)
+- `LDAP_OPT_X_KEEPALIVE_PROBES` (value data type int/long)
+- `LDAP_OPT_X_KEEPALIVE_INTERVAL` (value data type int/long)
+
+Supported TLS options
+
+- `LDAP_OPT_X_TLS_CACERTDIR` (value data type string/symbol)
+- `LDAP_OPT_X_TLS_CACERTFILE` (value data type string/symbol)
+- `LDAP_OPT_X_TLS_CERTFILE` (value data type string/symbol)
+- `LDAP_OPT_X_TLS_CIPHER_SUITE` (value data type string/symbol)
+- `LDAP_OPT_X_TLS_CRLCHECK` (value data type int/long)
+- `LDAP_OPT_X_TLS_CRLFILE` (value data type string/symbol)
+- `LDAP_OPT_X_TLS_DHFILE` (value data type string/symbol)
+- `LDAP_OPT_X_TLS_KEYFILE` (value data type string/symbol)
+- `LDAP_OPT_X_TLS_NEWCTX` (value data type int/long)
+- `LDAP_OPT_X_TLS_PROTOCOL_MIN` (value data type int/long)
+- `LDAP_OPT_X_TLS_RANDOM_FILE` (value data type string/symbol)
+- `LDAP_OPT_X_TLS_REQUIRE_CERT` (value data type int/long)
+
+### `.ldap.setGlobalOption`
+
+Sets options globally that affect LDAP operating procedures. LDAP handles inherit their default settings from the global options in  effect at the time the handle is created (i.e. if a global setting is made, all sessions initialized after that will inherit those settings but not any sessions created prior). 
+See `.ldap.setOption` for params and details.
+
+```txt
+.ldap.setGlobalOption[option;value]
+```
+
+### `.ldap.getOption`
+
+Gets session options that affect LDAP operating procedures. See [`ldap_set_option`](https://www.openldap.org/software/man.cgi?query=ldap_set_option&sektion=3&apropos=0&manpath=OpenLdap+2.4-Release)
+
+```txt
+.ldap.getOption[sess;option]
+```
+
+Where
+
+- `sess` is an int/long that represents the session previously created via `.ldap.init`
+- `option` is a symbol for the option you wish to get. See supported options below
+
+Value returned from function depends on options used. Supported LDAP options
+
+- `LDAP_OPT_API_FEATURE_INFO` (returns dict containing feature version info - subset of LDAP_OPT_API_INFO)
+- `LDAP_OPT_API_INFO` (returns dict containing API version info)
+- `LDAP_OPT_CONNECT_ASYNC` (returns int)
+- `LDAP_OPT_DEBUG_LEVEL` (returns int)
+- `LDAP_OPT_DEREF` (returns int)
+- `LDAP_OPT_DESC` (returns int)
+- `LDAP_OPT_DIAGNOSTIC_MESSAGE` (returns string)
+- `LDAP_OPT_MATCHED_DN` (returns string)
+- `LDAP_OPT_NETWORK_TIMEOUT` (return int representing microseconds)
+- `LDAP_OPT_PROTOCOL_VERSION` (returns int)
+- `LDAP_OPT_REFERRALS` (returns int)
+- `LDAP_OPT_RESULT_CODE` (returns int)
+- `LDAP_OPT_SIZELIMIT` (returns int)
+- `LDAP_OPT_TIMELIMIT` (returns int)
+- `LDAP_OPT_TIMEOUT` (return int representing microseconds)
+
+Supported SASL options
+
+- `LDAP_OPT_X_SASL_AUTHCID` (returns string)
+- `LDAP_OPT_X_SASL_AUTHZID` (returns string)
+- `LDAP_OPT_X_SASL_MAXBUFSIZE` (returns long)
+- `LDAP_OPT_X_SASL_MECH` (returns string)
+- `LDAP_OPT_X_SASL_MECHLIST` (returns string)
+- `LDAP_OPT_X_SASL_NOCANON` (returns int)
+- `LDAP_OPT_X_SASL_REALM` (returns string)
+- `LDAP_OPT_X_SASL_SSF` (returns long)
+- `LDAP_OPT_X_SASL_SSF_MAX` (returns long)
+- `LDAP_OPT_X_SASL_SSF_MIN` (returns long)
+- `LDAP_OPT_X_SASL_USERNAME` (returns string)
+
+Supported TCP options
+
+- `LDAP_OPT_X_KEEPALIVE_IDLE` (returns int)
+- `LDAP_OPT_X_KEEPALIVE_PROBES` (returns int)
+- `LDAP_OPT_X_KEEPALIVE_INTERVAL` (returns int)
+
+Supported TLS options
+
+`- LDAP_OPT_X_TLS_CACERTDIR` (returns string)
+`- LDAP_OPT_X_TLS_CACERTFILE` (returns string)
+`- LDAP_OPT_X_TLS_CERTFILE` (returns string)
+`- LDAP_OPT_X_TLS_CIPHER_SUITE` (returns string)
+`- LDAP_OPT_X_TLS_CRLCHECK` (returns int)
+`- LDAP_OPT_X_TLS_CRLFILE` (returns string)
+`- LDAP_OPT_X_TLS_DHFILE` (returns string)
+`- LDAP_OPT_X_TLS_KEYFILE` (returns string)
+`- LDAP_OPT_X_TLS_PROTOCOL_MIN` (returns int)
+`- LDAP_OPT_X_TLS_RANDOM_FILE` (returns string)
+`- LDAP_OPT_X_TLS_REQUIRE_CERT` (returns int)
+
+### `.ldap.getGlobalOption`
+
+Gets options globally that affect LDAP operating procedures. 
+See `.ldap.getOption` for details and parameter details
+
+```txt
+.ldap.getGlobalOption[option]
+```
+
+### `.ldap.startTLS`
+
+Using `ldaps://` (with the appropriate TLS/SSL options) will perform the TLS handshake automatically on connection.
+An alternative is to use `.ldap.startTLS`  for initializing a TLS handshake on a normal LDAP connection (calls [ldap_start_tls_s](https://linux.die.net/man/3/ldap_start_tls_s))
+
+`.ldap.startTLS` sends a StartTLS request to a server, waits for the reply, and then installs TLS handlers on the session if the request succeeded. The routine returns LDAP_SUCCESS if everything succeeded, otherwise it returns an LDAP error code.
+
+```txt
+.ldap.startTLS[sess]
+```
+
+### `.ldap.bind`
+
+Synchronous bind operations are used to authenticate clients (and the users or applications behind them) to the directory server, to establish an authorization identity that will be used for subsequent operations processed on that connection, and to specify the LDAP protocol version that the client will use. See [here](https://ldap.com/the-ldap-bind-operation/) for reference documentation
+
+```txt
+.ldap.bind[sess;dn;cred;mech]
+```
+
+Where
+
+- `sess` is an int/long that represents the session previously created via `.ldap.init`
+- `dn` is a string/symbol. The DN of the user to authenticate. This should be an empty string/symbol or generic null for anonymous simple authentication, and is typically empty for SASL authentication because most SASL mechanisms identify the target account in the encoded credentials. It must be non-empty for non-anonymous simple authentication.
+- `cred` is a char/byte array or symbol. LDAP credentials (e.g. password). Pass empty string/symbol or generic null when no password required for connection.
+- `mech` is a string/symbol. Pass an empty string or generic null to use the default `LDAP_SASL_SIMPLE` mechanism. Query the attribute `supportedSASLMechanisms` from the  server’s rootDSE for the list of SASL mechanisms the server supports.
+
+returns a dict consisting of 
+
+- `ReturnCode` - integer. See error code reference  within this document.
+- `Credentials` - byte array which is the credentials returned by the server. Contents are empty for `LDAP_SASL_SIMPLE`, though for other SASL mechanisms, the credentials may need to be used with other security related functions (which may be external to LDAP). See documentation for your security mechanism.
+
+#### Using security mechanisms
+
+LDAP supports a range of security mechanisms as part of the bind call. Check with your LDAP server/admin what is supported (often found in the root attribute named 'supportedSASLMechanisms').
+
+Most of the security mechanisms are performed externally, in separate code related to your security mechanism.
+
+For example,  `DIGEST_MD5` is initially performed by calling bind with no credentials, mech set to `"DIGEST-MD5"` and capturing the returned credential values from the server. Using the returned credentials to MD5-encode the user details, a second bind call is then made with the MD5 encoded details as the `cred` parameter. This requires an additional MD5 library that is outside the scope of this interface (Ref: [example code)](https://github.com/zheolong/melody-lib/blob/master/libldap5/sources/ldap/common/digest_md5.c). Other security mechanisms may operate in a similar manner (e.g. [GSSAPI](https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface) example [here](https://github.com/hajuuk/R7000/blob/master/ap/gpl/samba-3.0.13/source/libads/sasl.c), [CRAM-MD5](https://en.wikipedia.org/wiki/CRAM-MD5) available [here](https://github.com/illumos/illumos-gate/blob/master/usr/src/lib/libldap5/sources/ldap/common/cram_md5.c)).
+
+
+### `.ldap.search`
+
+_Synchronous search for partial or complete copies of entries based on a search criteria_
+
+```txt
+.ldap.search_s[sess;baseDn;scope;filter;attrs;attrsOnly;timeLimit;sizeLimit]
+```
+
+Where
+
+- `sess` is an int/long that represents the session previously created via .ldap.init
+- `baseDn` is a string/symbol. The base of the subtree to search from. An empty string/symbol or generic null can be used to search from the root (or when a DN is not known).
+- `scope`  is an int/long. Can be set to one of the following values:
+  - 0 (`LDAP_SCOPE_BASE`) Only the entry specified will be considered in the search & no subordinates used
+  - 1 (`LDAP_SCOPE_ONELEVEL`) Only search the immediate children of entry specified. Will not use the entry specified or further subordinates from the children.
+  - 2 (`LDAP_SCOPE_SUBTREE`) To search the entry and all subordinates
+  - 3 (`LDAP_SCOPE_CHILDREN`) To search all of the subordinates
+- `filter` is a string/symbol. The filter to be applied to the search ([reference](https://ldap.com/ldap-filters/))
+- `attrs` is a symbol list. The set of attributes to include in the result. If a specific set of attribute descriptions are listed, then only those attributes should be included in matching entries. The special value `*` indicates that all user attributes should be included in matching entries. The special value `+` indicates that all operational attributes should be included in matching entries. The special value `1.1` indicates that no attributes should be included in matching entries. Some servers may also support the ability to use the `@` symbol followed by an object class name (e.g., `@inetOrgPerson`) to request all attributes associated with that object class. If the set of attributes to request is an empty symbol/string or generic null, then the server should behave as if the value `*` was specified to request that all user attributes be included in entries that are returned.
+- `attrsOnly` is an int/long. Should be set to a non-zero value if only attribute descriptions are wanted. It should be set to zero (0) if both attributes descriptions and attribute values are wanted.
+- `timeLimit` is an int/long. Max number of microseconds to wait for a result. 0 represents no limit. Note that the server may impose its own limit.
+- `sizeLimit` is an int/long. Max number of entries to use in the result. 0 represents no limit. Note that the server may impose its own limit.
+
+returns a dict consisting of 
+
+- `ReturnCode` - integer. See error code reference within this document
+- `Entries` - table consisting of DNs and attributes. Attribute forms a dictionary, were each attribute may contain one or more values.
+- `Referrals` - list of strings providing the referrals that can be searched to gain access to the required info (if server supports referrals)
+
+### `.ldap.unbind`
+
+_Synchronous unbind from the directory, terminate the current association, and free resources_
+
+(Should be called even if a session did not bind (or failed to bind), but initialized its session.)
+
+```txt
+.ldap.unbind sess
+```
+
+Where `sess` is an int/long that represents the session previously created via `.ldap.init`. The number should no longer be used unless `.ldap.init` and `.ldap.bind_s` has been used to create a new session.
+
+
+### `.ldap.err2string`
+
+Returns a string description of an LDAP error code. The error codes are negative for an API error, 0 for success, and positive for a LDAP result code
+
+```txt
+.ldap.err2string err
+```
+
+Where `err` is an LDAP error code (see error code reference  within this document)
+
+## Error Code reference
+
+The function `.ldap.err2string` can provide a string representation of the error code.
+
+0 = Success
+
+### Protocol codes
+
+These are all positive values. See IANA registered result codes [here](https://www.iana.org/assignments/ldap-parameters/ldap-parameters.xhtml#ldap-parameters-6)
+
+### API error codes
+
+These are all negative values.
+
+| Code | Name                           | Details                                                      |
+| ---- | ------------------------------ | ------------------------------------------------------------ |
+| -1   | `LDAP_SERVER_DOWN`             | The LDAP library can't contact the LDAP server.              |
+| -2   | `LDAP_LOCAL_ERROR`             | Some local  error  occurred.   This  is  usually  a failed dynamic memory allocation. |
+| -3   | `LDAP_ENCODING_ERROR`          | An  error  was  encountered  encoding parameters to send to the LDAP server. |
+| -4   | `LDAP_DECODING_ERROR`          | An error was encountered decoding a result from the LDAP server. |
+| -5   | `LDAP_TIMEOUT`                 | A  timelimit  was  exceeded  while  waiting  for  a result.  |
+| -6   | `LDAP_AUTH_UNKNOWN`            | The authentication method specified to  `ldap_bind()`  is not known. |
+| -7   | `LDAP_FILTER_ERROR`            | An  invalid  filter  was  supplied to `ldap_search()` (e.g., unbalanced parentheses). |
+| -8   | `LDAP_USER_CANCELLED`          | The user cancelled the operation.                  |
+| -9   | `LDAP_PARAM_ERROR`             | An LDAP routine was called with a bad parameter.             |
+| -10  | `LDAP_NO_MEMORY`               | An memory  allocation  (e.g.,  [malloc(3)](https://www.openldap.org/software/man.cgi?query=malloc&sektion=3&apropos=0&manpath=OpenLdap+2.4-Release)  or  other  dynamic  memory  allocator)  call failed in an LDAP library routine. |
+| -11  | `LDAP_CONNECT_ERROR`           | Connection problem.                              |
+| -12  | `LDAP_NOT_SUPPORTED`           | The routine was called in  a  manner  not supported by the library. |
+| -13  | `LDAP_CONTROL_NOT_FOUND`       | The control  provided is unknown to the client library. |
+| -14  | `LDAP_NO_RESULTS_RETURNED`     | No results returned.                               |
+| -16  | `LDAP_CLIENT_LOOP`             | The library has detected a  loop  in  its processing. |
+| -17  | `LDAP_REFERRAL_LIMIT_EXCEEDED` | The referral limit has been exceeded.              |
+| -18  | `LDAP_X_CONNECTING`            | Async connect attempt is ongoing.                  |
+
+

--- a/documentation.md
+++ b/documentation.md
@@ -37,54 +37,54 @@ Sets options per session that affect LDAP operating procedures. Reference [ldap_
 
 Where
 
-- `sess` is an int/long that represents the session previously created via .ldap.init
-- `option` is a symbol for the option you wish to set. See supported options below.
+- `sess` is an int/long that represents the session previously created via `.ldap.init`<br>
+- `option` is a symbol for the option you wish to set. See supported options below.<br>
 - `value` is the value relating to the option. The data type depends on the option selected (see below)
 
 Supported LDAP options
 
-- `LDAP_OPT_CONNECT_ASYNC` (value data type int/long)
-- `LDAP_OPT_DEBUG_LEVEL` (value data type int/long)
-- `LDAP_OPT_DEREF` (value can be `.ldap.LDAP_DEREF_NEVER`, `.ldap.LDAP_DEREF_SEARCHING`, `.ldap.LDAP_DEREF_FINDING` or `.ldap.LDAP_DEREF_ALWAYS`)
-- `LDAP_OPT_DIAGNOSTIC_MESSAGE` (value data type string/symbol)
-- `LDAP_OPT_NETWORK_TIMEOUT` (value data type int/long - representing microseconds)
-- `LDAP_OPT_MATCHED_DN` (value data type string/symbol)
-- `LDAP_OPT_PROTOCOL_VERSION` (value data type int/long)
-- `LDAP_OPT_REFERRALS` (value can be `.ldap.LDAP_OPT_ON` or `.ldap.LDAP_OPT_OFF`)
-- `LDAP_OPT_RESULT_CODE` (value data type int/long)
-- `LDAP_OPT_SIZELIMIT` (value data type int/long)
-- `LDAP_OPT_TIMELIMIT` (value data type int/long)
-- `LDAP_OPT_TIMEOUT` (value data type int/long - representing microseconds)
+`LDAP_OPT_CONNECT_ASYNC` (value data type int/long)<br>
+`LDAP_OPT_DEBUG_LEVEL` (value data type int/long)<br>
+`LDAP_OPT_DEREF` (value can be `.ldap.LDAP_DEREF_NEVER`, `.ldap.LDAP_DEREF_SEARCHING`, `.ldap.LDAP_DEREF_FINDING` or `.ldap.LDAP_DEREF_ALWAYS`)<br>
+`LDAP_OPT_DIAGNOSTIC_MESSAGE` (value data type string/symbol)<br>
+`LDAP_OPT_NETWORK_TIMEOUT` (value data type int/long representing microseconds)<br>
+`LDAP_OPT_MATCHED_DN` (value data type string/symbol)<br>
+`LDAP_OPT_PROTOCOL_VERSION` (value data type int/long)<br>
+`LDAP_OPT_REFERRALS` (value can be `.ldap.LDAP_OPT_ON` or `.ldap.LDAP_OPT_OFF`)<br>
+`LDAP_OPT_RESULT_CODE` (value data type int/long)<br>
+`LDAP_OPT_SIZELIMIT` (value data type int/long)<br>
+`LDAP_OPT_TIMELIMIT` (value data type int/long)<br>
+`LDAP_OPT_TIMEOUT` (value data type int/long - representing microseconds)
 
 Supported SASL options
 
-- `LDAP_OPT_X_SASL_MAXBUFSIZE` (value data type long)
-- `LDAP_OPT_X_SASL_NOCANON` (value data type int/long)
-- `LDAP_OPT_X_SASL_SECPROPS` (value data type string/symbol)
-- `LDAP_OPT_X_SASL_SSF_EXTERNAL` (value data type long)
-- `LDAP_OPT_X_SASL_SSF_MAX` (value data type long)
-- `LDAP_OPT_X_SASL_SSF_MIN` (value data type long)
+`LDAP_OPT_X_SASL_MAXBUFSIZE` (value data type long)<br>
+`LDAP_OPT_X_SASL_NOCANON` (value data type int/long)<br>
+`LDAP_OPT_X_SASL_SECPROPS` (value data type string/symbol)<br>
+`LDAP_OPT_X_SASL_SSF_EXTERNAL` (value data type long)<br>
+`LDAP_OPT_X_SASL_SSF_MAX` (value data type long)<br>
+`LDAP_OPT_X_SASL_SSF_MIN` (value data type long)
 
 Supported TCP options
 
-- `LDAP_OPT_X_KEEPALIVE_IDLE` (value data type int/long)
-- `LDAP_OPT_X_KEEPALIVE_PROBES` (value data type int/long)
-- `LDAP_OPT_X_KEEPALIVE_INTERVAL` (value data type int/long)
+`LDAP_OPT_X_KEEPALIVE_IDLE` (value data type int/long)<br>
+`LDAP_OPT_X_KEEPALIVE_PROBES` (value data type int/long)<br>
+`LDAP_OPT_X_KEEPALIVE_INTERVAL` (value data type int/long)
 
 Supported TLS options
 
-- `LDAP_OPT_X_TLS_CACERTDIR` (value data type string/symbol)
-- `LDAP_OPT_X_TLS_CACERTFILE` (value data type string/symbol)
-- `LDAP_OPT_X_TLS_CERTFILE` (value data type string/symbol)
-- `LDAP_OPT_X_TLS_CIPHER_SUITE` (value data type string/symbol)
-- `LDAP_OPT_X_TLS_CRLCHECK` (value data type int/long)
-- `LDAP_OPT_X_TLS_CRLFILE` (value data type string/symbol)
-- `LDAP_OPT_X_TLS_DHFILE` (value data type string/symbol)
-- `LDAP_OPT_X_TLS_KEYFILE` (value data type string/symbol)
-- `LDAP_OPT_X_TLS_NEWCTX` (value data type int/long)
-- `LDAP_OPT_X_TLS_PROTOCOL_MIN` (value data type int/long)
-- `LDAP_OPT_X_TLS_RANDOM_FILE` (value data type string/symbol)
-- `LDAP_OPT_X_TLS_REQUIRE_CERT` (value data type int/long)
+`LDAP_OPT_X_TLS_CACERTDIR` (value data type string/symbol)<br>
+`LDAP_OPT_X_TLS_CACERTFILE` (value data type string/symbol)<br>
+`LDAP_OPT_X_TLS_CERTFILE` (value data type string/symbol)<br>
+`LDAP_OPT_X_TLS_CIPHER_SUITE` (value data type string/symbol)<br>
+`LDAP_OPT_X_TLS_CRLCHECK` (value data type int/long)<br>
+`LDAP_OPT_X_TLS_CRLFILE` (value data type string/symbol)<br>
+`LDAP_OPT_X_TLS_DHFILE` (value data type string/symbol)<br>
+`LDAP_OPT_X_TLS_KEYFILE` (value data type string/symbol)<br>
+`LDAP_OPT_X_TLS_NEWCTX` (value data type int/long)<br>
+`LDAP_OPT_X_TLS_PROTOCOL_MIN` (value data type int/long)<br>
+`LDAP_OPT_X_TLS_RANDOM_FILE` (value data type string/symbol)<br>
+`LDAP_OPT_X_TLS_REQUIRE_CERT` (value data type int/long)
 
 ### `.ldap.setGlobalOption`
 
@@ -110,55 +110,55 @@ Where
 
 Value returned from function depends on options used. Supported LDAP options
 
-- `LDAP_OPT_API_FEATURE_INFO` (returns dict containing feature version info - subset of LDAP_OPT_API_INFO)
-- `LDAP_OPT_API_INFO` (returns dict containing API version info)
-- `LDAP_OPT_CONNECT_ASYNC` (returns int)
-- `LDAP_OPT_DEBUG_LEVEL` (returns int)
-- `LDAP_OPT_DEREF` (returns int)
-- `LDAP_OPT_DESC` (returns int)
-- `LDAP_OPT_DIAGNOSTIC_MESSAGE` (returns string)
-- `LDAP_OPT_MATCHED_DN` (returns string)
-- `LDAP_OPT_NETWORK_TIMEOUT` (return int representing microseconds)
-- `LDAP_OPT_PROTOCOL_VERSION` (returns int)
-- `LDAP_OPT_REFERRALS` (returns int)
-- `LDAP_OPT_RESULT_CODE` (returns int)
-- `LDAP_OPT_SIZELIMIT` (returns int)
-- `LDAP_OPT_TIMELIMIT` (returns int)
+`LDAP_OPT_API_FEATURE_INFO` (returns dict containing feature version info - subset of `LDAP_OPT_API_INFO`)<br>
+`LDAP_OPT_API_INFO` (returns dict containing API version info)<br>
+`LDAP_OPT_CONNECT_ASYNC` (returns int)<br>
+`LDAP_OPT_DEBUG_LEVEL` (returns int)<br>
+`LDAP_OPT_DEREF` (returns int)<br>
+`LDAP_OPT_DESC` (returns int)<br>
+`LDAP_OPT_DIAGNOSTIC_MESSAGE` (returns string)<br>
+`LDAP_OPT_MATCHED_DN` (returns string)<br>
+`LDAP_OPT_NETWORK_TIMEOUT` (return int representing microseconds)<br>
+`LDAP_OPT_PROTOCOL_VERSION` (returns int)<br>
+`LDAP_OPT_REFERRALS` (returns int)<br>
+`LDAP_OPT_RESULT_CODE` (returns int)<br>
+`LDAP_OPT_SIZELIMIT` (returns int)<br>
+`LDAP_OPT_TIMELIMIT` (returns int)<br>
 - `LDAP_OPT_TIMEOUT` (return int representing microseconds)
 
 Supported SASL options
 
-- `LDAP_OPT_X_SASL_AUTHCID` (returns string)
-- `LDAP_OPT_X_SASL_AUTHZID` (returns string)
-- `LDAP_OPT_X_SASL_MAXBUFSIZE` (returns long)
-- `LDAP_OPT_X_SASL_MECH` (returns string)
-- `LDAP_OPT_X_SASL_MECHLIST` (returns string)
-- `LDAP_OPT_X_SASL_NOCANON` (returns int)
-- `LDAP_OPT_X_SASL_REALM` (returns string)
-- `LDAP_OPT_X_SASL_SSF` (returns long)
-- `LDAP_OPT_X_SASL_SSF_MAX` (returns long)
-- `LDAP_OPT_X_SASL_SSF_MIN` (returns long)
-- `LDAP_OPT_X_SASL_USERNAME` (returns string)
+`LDAP_OPT_X_SASL_AUTHCID` (returns string)<br>
+`LDAP_OPT_X_SASL_AUTHZID` (returns string)<br>
+`LDAP_OPT_X_SASL_MAXBUFSIZE` (returns long)<br>
+`LDAP_OPT_X_SASL_MECH` (returns string)<br>
+`LDAP_OPT_X_SASL_MECHLIST` (returns string)<br>
+`LDAP_OPT_X_SASL_NOCANON` (returns int)<br>
+`LDAP_OPT_X_SASL_REALM` (returns string)<br>
+`LDAP_OPT_X_SASL_SSF` (returns long)<br>
+`LDAP_OPT_X_SASL_SSF_MAX` (returns long)<br>
+`LDAP_OPT_X_SASL_SSF_MIN` (returns long)<br>
+`LDAP_OPT_X_SASL_USERNAME` (returns string)
 
 Supported TCP options
 
-- `LDAP_OPT_X_KEEPALIVE_IDLE` (returns int)
-- `LDAP_OPT_X_KEEPALIVE_PROBES` (returns int)
-- `LDAP_OPT_X_KEEPALIVE_INTERVAL` (returns int)
+`LDAP_OPT_X_KEEPALIVE_IDLE` (returns int)<br>
+`LDAP_OPT_X_KEEPALIVE_PROBES` (returns int)<br>
+`LDAP_OPT_X_KEEPALIVE_INTERVAL` (returns int)
 
 Supported TLS options
 
-`- LDAP_OPT_X_TLS_CACERTDIR` (returns string)
-`- LDAP_OPT_X_TLS_CACERTFILE` (returns string)
-`- LDAP_OPT_X_TLS_CERTFILE` (returns string)
-`- LDAP_OPT_X_TLS_CIPHER_SUITE` (returns string)
-`- LDAP_OPT_X_TLS_CRLCHECK` (returns int)
-`- LDAP_OPT_X_TLS_CRLFILE` (returns string)
-`- LDAP_OPT_X_TLS_DHFILE` (returns string)
-`- LDAP_OPT_X_TLS_KEYFILE` (returns string)
-`- LDAP_OPT_X_TLS_PROTOCOL_MIN` (returns int)
-`- LDAP_OPT_X_TLS_RANDOM_FILE` (returns string)
-`- LDAP_OPT_X_TLS_REQUIRE_CERT` (returns int)
+`LDAP_OPT_X_TLS_CACERTDIR` (returns string)<br>
+`LDAP_OPT_X_TLS_CACERTFILE` (returns string)<br>
+`LDAP_OPT_X_TLS_CERTFILE` (returns string)<br>
+`LDAP_OPT_X_TLS_CIPHER_SUITE` (returns string)<br>
+`LDAP_OPT_X_TLS_CRLCHECK` (returns int)<br>
+`LDAP_OPT_X_TLS_CRLFILE` (returns string)<br>
+`LDAP_OPT_X_TLS_DHFILE` (returns string)<br>
+`LDAP_OPT_X_TLS_KEYFILE` (returns string)<br>
+`LDAP_OPT_X_TLS_PROTOCOL_MIN` (returns int)<br>
+`LDAP_OPT_X_TLS_RANDOM_FILE` (returns string)<br>
+`LDAP_OPT_X_TLS_REQUIRE_CERT` (returns int)
 
 ### `.ldap.getGlobalOption`
 


### PR DESCRIPTION
To remove scope for conflict or duplication, the documentation will be removed from code.kx.com.

⚠️ **Please merge by 2023.03.01**

Imported docs are older than `README.md`

Converted imported MDs to GFM.

Moved content of `README.md` from second H1 onward to `documentation.md` and linked to it from `README.md` on premise that repo content is more current than imported MDs.

TO DO: resolve duplication or conflicts between repo’s and imported MDs